### PR TITLE
porting strict context parser to context parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 HTML5 Context Parser
 ====================
-
 HTML5 Context Parser is a robust and small footprint HTML5 context parser that parses HTML 5 web pages and reports the execution context of each character seen.
+
+[![npm version][npm-badge]][npm]
+[![dependency status][dep-badge]][dep-status]
+
+[npm]: https://www.npmjs.org/package/context-parser
+[npm-badge]: https://img.shields.io/npm/v/context-parser.svg?style=flat-square
+[dep-status]: https://david-dm.org/yahoo/context-parser
+[dep-badge]: https://img.shields.io/david/yahoo/context-parser.svg?style=flat-square
 
 ## Overview
 

--- a/bin/context-dump
+++ b/bin/context-dump
@@ -14,24 +14,36 @@ Debug.enable(progname);
     var Parser = require("../src/context-parser").Parser,
         debug = Debug(progname),
         fs = require('fs'),
-        file,
-        noofargs = 0,
-        parser = new Parser();
+        file, 
+        enableInputPreProcessing = false, enableCanonicalization = false, enableIEConditionalComments = false, enableStateTracking = true,
+        noofargs = 0;
 
     process.argv.forEach(function(val, index) {
         ++noofargs;
         if (index === 2) {
             file = val;
+        } else if (index === 3) {
+            enableInputPreProcessing = val === "1"? true:false;
+        } else if (index === 4) {
+            enableCanonicalization = val === "1"? true:false;
         }
     });
+
+    var config = {
+        enableInputPreProcessing: enableInputPreProcessing,
+        enableCanonicalization: enableCanonicalization,
+        enableIEConditionalComments: enableIEConditionalComments,
+        enableStateTracking: enableStateTracking 
+    }, 
+        parser = new Parser(config);
 
     Parser.prototype.printCharWithState = function() {
         var len = this.states.length;
         debug('{ statesSize: '+len+' }');
         for(var i=0;i<len;i++) {
-            var c = this.bytes[i];
+            var c = this.buffer[i];
             var s = this.states[i];
-            var t = this.symbols[i];
+            var t = this.symbol[i];
 
             if (i === 0) {
                 debug('{ ch: 0, state: '+s+', symbol: 0 }');
@@ -49,7 +61,7 @@ Debug.enable(progname);
         return 0;
     };
 
-    if (noofargs === 3) {
+    if (noofargs <= 5) {
         if (fs.existsSync(file)) {
             var data = fs.readFileSync(file, 'utf-8');
             parser.contextualize(data, data.length);            
@@ -60,7 +72,7 @@ Debug.enable(progname);
             process.exit(1);
         }
     } else {
-        console.log("Usage: context-dump <any html file>");
+        console.log("Usage: context-dump <html file> <input preprocessing:0|1> <canonicalization:0|1>");
         process.exit(1);
     }
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "clean": "grunt clean",
     "test": "grunt test"
   },
-  "dependencies": {},
   "devDependencies": {
+    "chai": "^2.3.0",
     "debug": "^2.*",
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-parser",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "licenses": [
     {
       "type": "BSD",

--- a/src/context-parser.js
+++ b/src/context-parser.js
@@ -416,9 +416,11 @@ function Parser (config, listeners) {
         this.config.enableStateTracking = true;
         this.states = [this.state];
         this.buffer = []; 
+        this.symbol = []; 
         this.on('postWalk', function (lastState, state, i, endsWithEOF) {
             this.buffer.push(this.input[i]);
             this.states.push(state);
+            this.symbol.push(this._getSymbol(i));
         }).on('reWalk', this.setCurrentState);
     }
 }

--- a/src/context-parser.js
+++ b/src/context-parser.js
@@ -8,11 +8,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
          Adonis Fung <adon@yahoo-inc.com>
 */
 /*jshint -W030 */
-
 (function() {
 "use strict";
 
-var stateMachine = require('./html5-state-machine.js');
+var stateMachine = require('./html5-state-machine.js'),
+    htmlState = stateMachine.State;
+
 /**
  * @class FastParser
  * @constructor FastParser
@@ -43,10 +44,35 @@ function FastParser() {
  */
 FastParser.prototype.on = function (eventType, listener) {
     var l = this.listeners[eventType];
-    if (l) {
-        l.push(listener);
-    } else {
-        this.listeners[eventType] = [listener];
+    if (listener) {
+        if (l) {
+            l.push(listener);
+        } else {
+            this.listeners[eventType] = [listener];
+        }
+    }
+    return this;
+};
+
+/**
+ * @function FastParser#once
+ *
+ * @param {string} eventType - the event type (e.g., preWalk, reWalk, postWalk, ...)
+ * @param {function} listener - the event listener
+ * @returns this
+ *
+ * @description
+ * <p>register the given event listener to the given eventType, for which it will be fired only once</p>
+ *
+ */
+FastParser.prototype.once = function(eventType, listener) {
+    var self = this, onceListener;
+    if (listener) {
+        onceListener = function () {
+            self.off(eventType, onceListener);
+            listener.apply(self, arguments);
+        };
+        return this.on(eventType, onceListener);
     }
     return this;
 };
@@ -62,12 +88,16 @@ FastParser.prototype.on = function (eventType, listener) {
  * <p>remove the listener from being fired when the eventType happen</p>
  *
  */
-FastParser.prototype.off = function (listeners, listener) {
-    var i = listeners.length;
-    while (--i) {
-        if (listeners[i] === listener) {
-            listeners.splice(i, 1);
-            break;
+FastParser.prototype.off = function (eventType, listener) {
+    if (listener) {
+        var i, len, listeners = this.listeners[eventType];
+        if (listeners) {
+            for (i = 0; listeners[i]; i++) {
+                if (listeners[i] === listener) {
+                    listeners.splice(i, 1);
+                    break;
+                }
+            }
         }
     }
     return this;
@@ -84,13 +114,14 @@ FastParser.prototype.off = function (listeners, listener) {
  *
  */
 FastParser.prototype.emit = function (listeners, args) {
-    var i = -1, len;
-    if ((len = listeners.length)) {
-        while (++i < len) {
-            listeners[i].apply(this, args || []);
+    if (listeners) {
+        var i = -1, len;
+        if ((len = listeners.length)) {
+            while (++i < len) {
+                listeners[i].apply(this, args || []);
+            }
         }
     }
-
     return this;
 };
 
@@ -286,6 +317,7 @@ FastParser.prototype.contextualize = function(input, endsWithEOF) {
  *
  */
 FastParser.prototype.beforeWalk = function (i, input) {};
+
 /**
  * @function FastParser#afterWalk
  *
@@ -297,7 +329,6 @@ FastParser.prototype.beforeWalk = function (i, input) {};
  *
  */
 FastParser.prototype.afterWalk = function (i, input) {};
-
 
 /**
  * @function FastParser#getStartTagName
@@ -336,20 +367,17 @@ FastParser.prototype.getAttributeValue = function(htmlDecoded) {
     return this.attributeValue;
 };
 
-
-
-
-
-
-
-
-
-
-
+/**
+* @module Parser
+*/
 function Parser (config, listeners) {
     var self = this, k;
 
+    // super constructor
     FastParser.call(self);
+
+    // config
+    config || (config = {});
 
     // deep copy config to this.config
     self.config = {};
@@ -369,8 +397,23 @@ function Parser (config, listeners) {
         return;
     }
 
+    // run through the input stream with input pre-processing
+    this.config.disableInputPreProcessing = (config.disableInputPreProcessing === undefined || config.disableInputPreProcessing)? true:false;
+    this.config.disableInputPreProcessing && this.on('preWalk', InputPreProcessing);
+    // fix parse errors before they're encountered in walk()
+    this.config.disableCanonicalization = (config.disableCanonicalization === undefined || config.disableCanonicalization === false)? false:true;
+    this.config.disableCanonicalization && this.on('preWalk', Canonicalize).on('reWalk', Canonicalize);
+    // disable IE conditional comments
+    this.config.disableIEConditionalComments = (config.disableIEConditionalComments === undefined || config.disableIEConditionalComments === false)? false:true;
+    this.config.disableIEConditionalComments && this.on('preWalk', DisableIEConditionalComments);
+    // TODO: rewrite IE <comment> tags
+    // TODO: When a start tag token is emitted with its self-closing flag set, if the flag is not acknowledged when it is processed by the tree construction stage, that is a parse error.
+    // TODO: When an end tag token is emitted with attributes, that is a parse error.
+    // TODO: When an end tag token is emitted with its self-closing flag set, that is a parse error.
+
     // for bookkeeping the processed inputs and states
-    if (!config.disableHistoryTracking) {
+    if (config.enableStateTracking === undefined || config.enableStateTracking) {
+        this.config.enableStateTracking = true;
         this.states = [this.state];
         this.buffer = []; 
         this.on('postWalk', function (lastState, state, i, endsWithEOF) {
@@ -384,8 +427,52 @@ function Parser (config, listeners) {
 Parser.prototype = Object.create(FastParser.prototype);
 Parser.prototype.constructor = Parser;
 
+/**
+* @function Parser._getSymbol
+* @param {integer} i - the index of input stream
+*
+* @description
+* Get the html symbol mapping for the character located in the given index of input stream
+*/
+Parser.prototype._getSymbol = function (i) {
+    return i < this.inputLen ? this.lookupChar(this.input[i]) : -1;
+};
 
+/**
+* @function Parser._getNextState
+* @param {integer} state - the current state
+* @param {integer} i - the index of input stream
+* @returns {integer} the potential state about to transition into, given the current state and an index of input stream
+*
+* @description
+* Get the potential html state about to transition into
+*/
+Parser.prototype._getNextState = function (state, i, endsWithEOF) {
+    return i < this.inputLen ? stateMachine.lookupStateFromSymbol[this._getSymbol(i)][state] : -1;
+};
 
+/**
+* @function Parser.fork
+* @returns {object} a new parser with all internal states inherited
+*
+* @description
+* create a new parser with all internal states inherited
+*/
+Parser.prototype.fork = function() {
+    var parser = new this.constructor(this.config, this.listeners);
+
+    parser.state = this.state;
+    parser.tags = this.tags.slice();
+    parser.tagIdx = this.tagIdx;
+    parser.attributeName = this.attributeName;
+    parser.attributeValue = this.attributeValue;
+
+    if (this.config.enableStateTracking) {
+        parser.buffer = this.buffer.slice();
+        parser.states = this.states.slice();
+    }
+    return parser;
+};
 
 /**
  * @function Parser#parsePartial
@@ -414,8 +501,6 @@ Parser.prototype.contextualize = function (input, endsWithEOF) {
     return FastParser.prototype.contextualize.call(this, input, endsWithEOF);
 };
 
-
-
 /**
  * @function Parser#setCurrentState
  *
@@ -429,6 +514,19 @@ Parser.prototype.setCurrentState = function(state) {
     this.states.pop();
     this.states.push(this.state = state);
     return this;
+};
+
+/**
+ * @function Parser#getCurrentState
+ *
+ * @returns {integer} The last state of the HTML5 Context Parser.
+ *
+ * @description
+ * Get the last state of HTML5 Context Parser.
+ *
+ */
+Parser.prototype.getCurrentState = function() {
+    return this.state;
 };
 
 /**
@@ -485,7 +583,303 @@ Parser.prototype.getLastState = function() {
     return this.states[ this.states.length - 1 ];
 };
 
+/**
+* The implementation of Strict Context Parser functions
+* 
+* - InputPreProcessing
+* - ConvertBogusCommentToComment
+* - PreCanonicalizeConvertBogusCommentEndTag
+* - Canonicalize
+* - DisableIEConditionalComments
+*
+*/
 
+// Perform input stream preprocessing
+// Reference: https://html.spec.whatwg.org/multipage/syntax.html#preprocessing-the-input-stream
+function InputPreProcessing (state, i) {
+    var input = this.input,
+        chr = input[i],
+        nextChr = input[i+1];
+
+    // equivalent to inputStr.replace(/\r\n?/g, '\n')
+    if (chr === '\r') {
+        if (nextChr === '\n') {
+            input.splice(i, 1);
+            this.inputLen--;
+        } else {
+            input[i] = '\n';
+        }
+    }
+    // the following are control characters or permanently undefined Unicode characters (noncharacters), resulting in parse errors
+    // \uFFFD replacement is not required by the specification, we consider \uFFFD character as an inert character
+    else if ((chr >= '\x01'   && chr <= '\x08') ||
+             (chr >= '\x0E'   && chr <= '\x1F') ||
+             (chr >= '\x7F'   && chr <= '\x9F') ||
+             (chr >= '\uFDD0' && chr <= '\uFDEF') ||
+             chr === '\x0B' || chr === '\uFFFE' || chr === '\uFFFF') {
+        input[i] = '\uFFFD';
+    }
+    // U+1FFFE, U+1FFFF, U+2FFFE, U+2FFFF, U+3FFFE, U+3FFFF,
+    // U+4FFFE, U+4FFFF, U+5FFFE, U+5FFFF, U+6FFFE, U+6FFFF,
+    // U+7FFFE, U+7FFFF, U+8FFFE, U+8FFFF, U+9FFFE, U+9FFFF,
+    // U+AFFFE, U+AFFFF, U+BFFFE, U+BFFFF, U+CFFFE, U+CFFFF,
+    // U+DFFFE, U+DFFFF, U+EFFFE, U+EFFFF, U+FFFFE, U+FFFFF,
+    // U+10FFFE, and U+10FFFF
+    else if ((nextChr === '\uDFFE' || nextChr === '\uDFFF') &&
+             (  chr === '\uD83F' || chr === '\uD87F' || chr === '\uD8BF' || chr === '\uD8FF' ||
+                chr === '\uD93F' || chr === '\uD97F' || chr === '\uD9BF' || chr === '\uD9FF' ||
+                chr === '\uDA3F' || chr === '\uDA7F' || chr === '\uDABF' || chr === '\uDAFF' ||
+                chr === '\uDB3F' || chr === '\uDB7F' || chr === '\uDBBF' || chr === '\uDBFF')) {
+        input[i] = input[i+1] = '\uFFFD';
+    }
+}
+
+function ConvertBogusCommentToComment(i) {
+    // convert !--. i.e., from <* to <!--*
+    this.input.splice(i, 0, '!', '-', '-');
+    this.inputLen += 3;
+
+    // convert the next > to -->
+    this.on('preCanonicalize', PreCanonicalizeConvertBogusCommentEndTag);
+}
+
+function PreCanonicalizeConvertBogusCommentEndTag(state, i, endsWithEOF) {
+    if (this.input[i] === '>') {
+        // remove itself from the listener list
+        this.off('preCanonicalize', PreCanonicalizeConvertBogusCommentEndTag);
+
+        // convert [>] to [-]->
+        this.input.splice(i, 0, '-', '-');
+        this.inputLen += 2;
+
+        this.emit(this.listeners.bogusCommentCoverted, [state, i, endsWithEOF]);
+    }
+}
+
+// those doctype states (52-67) are initially treated as bogus comment state, but they are further converted to comment state
+// Canonicalize() will create no more bogus comment state except the fake (context-parser treats <!doctype as bogus) one hardcoded as <!doctype html> that has no NULL inside
+var statesRequiringNullReplacement = [
+//    0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+/*0*/ 0, 0, 0, 1, 0, 1, 1, 1, 0, 0,
+/*1*/ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+/*2*/ 0, 0, 1, 1, 1, 0, 0, 0, 0, 1,
+/*3*/ 1, 1, 0, 0, 1, 1, 1, 1, 1, 1,
+/*4*/ 1, 0, 0, 0, 1, 0, 1, 1, 1, 1,
+/*5*/ 1, 1
+];
+// \uFFFD replacement is not required by the spec for DATA state
+statesRequiringNullReplacement[htmlState.STATE_DATA] = 1;
+
+function Canonicalize(state, i, endsWithEOF) {
+
+    this.emit(this.listeners.preCanonicalize, [state, i, endsWithEOF]);
+
+    var reCanonicalizeNeeded = true,
+        input = this.input,
+        chr = input[i], nextChr = input[i+1],
+        potentialState = this._getNextState(state, i, endsWithEOF),
+        nextPotentialState = this._getNextState(potentialState, i + 1, endsWithEOF);
+
+    // console.log(i, state, potentialState, nextPotentialState, input.slice(i).join(''));
+
+    // batch replacement of NULL with \uFFFD would violate the spec
+    //  - for example, NULL is untouched in CDATA section state
+    if (chr === '\x00' && statesRequiringNullReplacement[state]) {
+        input[i] = '\uFFFD';
+    }
+    // encode < into &lt; for [<]* (* is non-alpha) in STATE_DATA, [<]% and [<]! in STATE_RCDATA and STATE_RAWTEXT
+    else if ((potentialState === htmlState.STATE_TAG_OPEN && nextPotentialState === htmlState.STATE_DATA) ||  // [<]*, where * is non-alpha
+             ((state === htmlState.STATE_RCDATA || state === htmlState.STATE_RAWTEXT) &&                            // in STATE_RCDATA and STATE_RAWTEXT
+            chr === '<' && (nextChr === '%' || nextChr === '!'))) {   // [<]% or [<]!
+
+        // [<]*, [<]%, [<]!
+        input.splice(i, 1, '&', 'l', 't', ';');
+        this.inputLen += 3;
+    }
+    // enforce <!doctype html>
+    // + convert bogus comment or unknown doctype to the standard html comment
+    else if (potentialState === htmlState.STATE_MARKUP_DECLARATION_OPEN) {            // <[!]***
+        reCanonicalizeNeeded = false;
+
+        // context-parser treats the doctype and [CDATA[ as resulting into STATE_BOGUS_COMMENT
+        // so, we need our algorithm here to extract and check the next 7 characters
+        var commentKey = input.slice(i + 1, i + 8).join('');
+
+        // enforce <!doctype html>
+        if (commentKey.toLowerCase() === 'doctype') {               // <![d]octype
+            // extract 6 chars immediately after <![d]octype and check if it's equal to ' html>'
+            if (input.slice(i + 8, i + 14).join('').toLowerCase() !== ' html>') {
+
+                // replace <[!]doctype xxxx> with <[!]--!doctype xxxx--><doctype html>
+                ConvertBogusCommentToComment.call(this, i);
+
+                this.once('bogusCommentCoverted', function (state, i) {
+                    [].splice.apply(this.input, [i + 3, 0].concat('<!doctype html>'.split('')));
+                    this.inputLen += 15;
+                });
+
+                reCanonicalizeNeeded = true;
+            }
+        }
+        // do not touch <![CDATA[ and <[!]--
+        else if (commentKey === '[CDATA[' ||
+                    (nextChr === '-' && input[i+2] === '-')) {
+            // noop
+        }
+        // ends up in bogus comment
+        else {
+            // replace <[!]*** with <[!]--***
+            // will replace the next > to -->
+            ConvertBogusCommentToComment.call(this, i);
+            reCanonicalizeNeeded = true;
+        }
+    }
+    // convert bogus comment to the standard html comment
+    else if ((state === htmlState.STATE_TAG_OPEN &&
+             potentialState === htmlState.STATE_BOGUS_COMMENT) ||           // <[?] only from STATE_TAG_OPEN
+            (potentialState === htmlState.STATE_END_TAG_OPEN &&             // <[/]* or <[/]> from STATE_END_TAG_OPEN
+             nextPotentialState !== htmlState.STATE_TAG_NAME &&
+             nextPotentialState !== -1)) {                                  // TODO: double check if there're any other cases requiring -1 check
+        // replace <? and </* respectively with <!--? and <!--/*
+        // will replace the next > to -->
+        ConvertBogusCommentToComment.call(this, i);
+    }
+    // remove the unnecessary SOLIDUS
+    else if (potentialState === htmlState.STATE_SELF_CLOSING_START_TAG &&             // <***[/]*
+            nextPotentialState === htmlState.STATE_BEFORE_ATTRIBUTE_NAME) {           // input[i+1] is ANYTHING_ELSE (i.e., not EOF nor >)
+        // if ([htmlState.STATE_TAG_NAME,                                             // <a[/]* replaced with <a[ ]*
+        //     /* following is unknown to CP
+        //     htmlState.STATE_RCDATA_END_TAG_NAME,
+        //     htmlState.STATE_RAWTEXT_END_TAG_NAME,
+        //     htmlState.STATE_SCRIPT_DATA_END_TAG_NAME,
+        //     htmlState.STATE_SCRIPT_DATA_ESCAPED_END_TAG_NAME,
+        //     */
+        //     htmlState.STATE_BEFORE_ATTRIBUTE_NAME,                                 // <a [/]* replaced with <a [ ]*
+        //     htmlState.STATE_AFTER_ATTRIBUTE_VALUE_QUOTED].indexOf(state) !== -1)   // <a abc=""[/]* replaced with <a abc=""[ ]*
+        input[i] = ' ';
+
+        // given input[i] was    '/', nextPotentialState was htmlState.STATE_BEFORE_ATTRIBUTE_NAME
+        // given input[i] is now ' ', nextPotentialState becomes STATE_BEFORE_ATTRIBUTE_NAME if current state is STATE_ATTRIBUTE_NAME or STATE_AFTER_ATTRIBUTE_NAME
+        // to preserve state, remove future EQUAL SIGNs (=)s to force STATE_AFTER_ATTRIBUTE_NAME behave as if it is STATE_BEFORE_ATTRIBUTE_NAME
+        // this is okay since EQUAL SIGNs (=)s will be stripped anyway in the STATE_BEFORE_ATTRIBUTE_NAME cleanup handling
+        if (state === htmlState.STATE_ATTRIBUTE_NAME ||                               // <a abc[/]=abc  replaced with <a abc[ ]*
+                state === htmlState.STATE_AFTER_ATTRIBUTE_NAME) {                     // <a abc [/]=abc replaced with <a abc [ ]*
+            for (var j = i + 1; j < this.inputLen && input[j] === '='; j++) {
+                input.splice(j, 1);
+                this.inputLen--;
+            }
+        }
+    }
+    // remove unnecessary equal signs, hence <input checked[=]> become <input checked[>], or <input checked [=]> become <input checked [>]
+    else if (potentialState === htmlState.STATE_BEFORE_ATTRIBUTE_VALUE &&   // only from STATE_ATTRIBUTE_NAME or STATE_AFTER_ATTRIBUTE_NAME
+            nextPotentialState === htmlState.STATE_DATA) {                  // <a abc[=]> or <a abc [=]>
+        input.splice(i, 1);
+        this.inputLen--;
+    }
+    // insert a space for <a abc="***["]* or <a abc='***[']* after quoted attribute value (i.e., <a abc="***["] * or <a abc='***['] *)
+    else if (potentialState === htmlState.STATE_AFTER_ATTRIBUTE_VALUE_QUOTED &&        // <a abc=""[*] where * is not SPACE (\t,\n,\f,' ')
+            nextPotentialState === htmlState.STATE_BEFORE_ATTRIBUTE_NAME &&
+            this._getSymbol(i + 1) !== stateMachine.Symbol.SPACE) {
+        input.splice(i + 1, 0, ' ');
+        this.inputLen++;
+    }
+    // else here means no special pattern was found requiring rewriting
+    else {
+        reCanonicalizeNeeded = false;
+    }
+
+    // remove " ' < = from being treated as part of attribute name (not as the spec recommends though)
+    switch (potentialState) {
+        case htmlState.STATE_BEFORE_ATTRIBUTE_NAME:     // remove ambigious symbols in <a [*]href where * is ", ', <, or =
+            if (nextChr === "=") {
+                input.splice(i + 1, 1);
+                this.inputLen--;
+                reCanonicalizeNeeded = true;
+                break;
+            }
+            /* falls through */
+        case htmlState.STATE_ATTRIBUTE_NAME:            // remove ambigious symbols in <a href[*] where * is ", ', or <
+        case htmlState.STATE_AFTER_ATTRIBUTE_NAME:      // remove ambigious symbols in <a href [*] where * is ", ', or <
+            if (nextChr === '"' || nextChr === "'" || nextChr === '<') {
+                input.splice(i + 1, 1);
+                this.inputLen--;
+                reCanonicalizeNeeded = true;
+            }
+            break;
+    }
+
+    if (reCanonicalizeNeeded) {
+        return Canonicalize.call(this, state, i, endsWithEOF);
+    }
+
+    switch (state) {
+    // escape " ' < = ` to avoid raising parse errors for unquoted value
+        case htmlState.STATE_ATTRIBUTE_VALUE_UNQUOTED:
+            if (chr === '"') {
+                input.splice(i, 1, '&', 'q', 'u', 'o', 't', ';');
+                this.inputLen += 5;
+                break;
+            } else if (chr === "'") {
+                input.splice(i, 1, '&', '#', '3', '9', ';');
+                this.inputLen += 4;
+                break;
+            }
+            /* falls through */
+        case htmlState.STATE_BEFORE_ATTRIBUTE_VALUE:     // treat < = ` as if they are in STATE_ATTRIBUTE_VALUE_UNQUOTED
+            if (chr === '<') {
+                input.splice(i, 1, '&', 'l', 't', ';');
+                this.inputLen += 3;
+            } else if (chr === '=') {
+                input.splice(i, 1, '&', '#', '6', '1', ';');
+                this.inputLen += 4;
+            } else if (chr === '`') {
+                input.splice(i, 1, '&', '#', '9', '6', ';');
+                this.inputLen += 4;
+            }
+            break;
+
+    // add hyphens to complete <!----> to avoid raising parsing errors
+        // replace <!--[>] with <!--[-]->
+        case htmlState.STATE_COMMENT_START:
+            if (chr === '>') {                          // <!--[>]
+                input.splice(i, 0, '-', '-');
+                this.inputLen += 2;
+                // reCanonicalizeNeeded = true;  // not need due to no where to treat its potential states
+            }
+            break;
+        // replace <!---[>] with <!---[-]>
+        case htmlState.STATE_COMMENT_START_DASH:
+            if (chr === '>') {                          // <!---[>]
+                input.splice(i, 0, '-');
+                this.inputLen++;
+                // reCanonicalizeNeeded = true;  // not need due to no where to treat its potential states
+            }
+            break;
+    // replace --[!]> with --[>]
+        case htmlState.STATE_COMMENT_END:
+            if (chr === '!' && nextChr === '>') {
+                input.splice(i, 1);
+                this.inputLen--;
+                // reCanonicalizeNeeded = true;  // not need due to no where to treat its potential states
+            }
+            // if (chr === '-'), ignored this parse error. TODO: consider stripping n-2 hyphens for ------>
+            break;
+    }
+
+    if (reCanonicalizeNeeded) {
+        return Canonicalize.call(this, state, i, endsWithEOF);
+    }
+}
+
+// remove IE conditional comments
+function DisableIEConditionalComments(state, i){
+    var input = this.input;
+
+    if (state === htmlState.STATE_COMMENT && input[i] === ']' && input[i+1] === '>') {
+        input.splice(i, 0, ' ');
+        this.inputLen++;
+    }
+}
 
 module.exports = {
     Parser: Parser,

--- a/src/context-parser.js
+++ b/src/context-parser.js
@@ -398,7 +398,7 @@ function Parser (config, listeners) {
     }
 
     // run through the input stream with input pre-processing
-    this.config.enableInputPreProcessing = (config.enableInputPreProcessing === undefined || config.enableInputPreProcessing)? true:false;
+    this.config.enableInputPreProcessing = (config.enableInputPreProcessing === undefined || config.enableInputPreProcessing === false)? false:true;
     this.config.enableInputPreProcessing && this.on('preWalk', InputPreProcessing);
     // fix parse errors before they're encountered in walk()
     this.config.enableCanonicalization = (config.enableCanonicalization === undefined || config.enableCanonicalization === false)? false:true;
@@ -485,7 +485,7 @@ Parser.prototype.fork = function() {
  */
 Parser.prototype.contextualize = function (input, endsWithEOF) {
     this.setInitState(this.getInitState());
-    if (this.config.enableCanonicalization) { // only Canonicalization will modify the input stream
+    if (this.config.enableInputPreProcessing || this.config.enableCanonicalization) {
         input = input.split('');
         FastParser.prototype.contextualize.call(this, input, endsWithEOF);
         return input.join('');

--- a/src/context-parser.js
+++ b/src/context-parser.js
@@ -398,14 +398,14 @@ function Parser (config, listeners) {
     }
 
     // run through the input stream with input pre-processing
-    this.config.disableInputPreProcessing = (config.disableInputPreProcessing === undefined || config.disableInputPreProcessing)? true:false;
-    this.config.disableInputPreProcessing && this.on('preWalk', InputPreProcessing);
+    this.config.enableInputPreProcessing = (config.enableInputPreProcessing === undefined || config.enableInputPreProcessing)? true:false;
+    this.config.enableInputPreProcessing && this.on('preWalk', InputPreProcessing);
     // fix parse errors before they're encountered in walk()
-    this.config.disableCanonicalization = (config.disableCanonicalization === undefined || config.disableCanonicalization === false)? false:true;
-    this.config.disableCanonicalization && this.on('preWalk', Canonicalize).on('reWalk', Canonicalize);
-    // disable IE conditional comments
-    this.config.disableIEConditionalComments = (config.disableIEConditionalComments === undefined || config.disableIEConditionalComments === false)? false:true;
-    this.config.disableIEConditionalComments && this.on('preWalk', DisableIEConditionalComments);
+    this.config.enableCanonicalization = (config.enableCanonicalization === undefined || config.enableCanonicalization === false)? false:true;
+    this.config.enableCanonicalization && this.on('preWalk', Canonicalize).on('reWalk', Canonicalize);
+    // enable IE conditional comments
+    this.config.enableIEConditionalComments = (config.enableIEConditionalComments === undefined || config.enableIEConditionalComments === false)? false:true;
+    this.config.enableIEConditionalComments && this.on('preWalk', DisableIEConditionalComments);
     // TODO: rewrite IE <comment> tags
     // TODO: When a start tag token is emitted with its self-closing flag set, if the flag is not acknowledged when it is processed by the tree construction stage, that is a parse error.
     // TODO: When an end tag token is emitted with attributes, that is a parse error.
@@ -475,30 +475,23 @@ Parser.prototype.fork = function() {
 };
 
 /**
- * @function Parser#parsePartial
- *
- * @param {string} input - The HTML fragment
- * @returns {string} The processed HTML fragment, which might be altered by preWalk, reWalk or postWalk
- *
- * @description
- * It differs from contextualize() by converting input internally to be an array to facilitate altering
- */
-Parser.prototype.parsePartial = function(input, endsWithEOF) {
-    input = input.split('');
-    FastParser.prototype.contextualize.call(this, input, endsWithEOF);
-    return input.join('');
-};
-
-/**
  * @function Parser#contextualize
  * @param {string} input - the input stream
  *
  * @description
- * It is the same as the original contextualize() except that this method always resets to its initial state before processing
+ * It is the same as the original contextualize() except that this method always resets to its initial state before processing.
+ *
+ * If the Canonicalization is enabled, it converts an input string to be an array to facilitate altering.
  */
 Parser.prototype.contextualize = function (input, endsWithEOF) {
     this.setInitState(this.getInitState());
-    return FastParser.prototype.contextualize.call(this, input, endsWithEOF);
+    if (this.config.enableCanonicalization) { // only Canonicalization will modify the input stream
+        input = input.split('');
+        FastParser.prototype.contextualize.call(this, input, endsWithEOF);
+        return input.join('');
+    } else {
+        return FastParser.prototype.contextualize.call(this, input, endsWithEOF);
+    }
 };
 
 /**

--- a/src/context-parser.js
+++ b/src/context-parser.js
@@ -472,6 +472,7 @@ Parser.prototype.fork = function() {
     if (this.config.enableStateTracking) {
         parser.buffer = this.buffer.slice();
         parser.states = this.states.slice();
+        parser.symbol = this.symbol.slice();
     }
     return parser;
 };

--- a/tests/unit/run-bug-spec.js
+++ b/tests/unit/run-bug-spec.js
@@ -14,9 +14,9 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         fs = require("fs");
 
     var config = {
-        disableInputPreProcessing: false,
-        disableCanonicalization: false,
-        disableIEConditionalComments: false
+        enableInputPreProcessing: false,
+        enableCanonicalization: false,
+        enableIEConditionalComments: false
     };
 
     describe('HTML5 Context Parser with Buggy Subclass Prototype', function(){

--- a/tests/unit/run-bug-spec.js
+++ b/tests/unit/run-bug-spec.js
@@ -13,6 +13,12 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
     var expect = require("expect.js"),
         fs = require("fs");
 
+    var config = {
+        disableInputPreProcessing: false,
+        disableCanonicalization: false,
+        disableIEConditionalComments: false
+    };
+
     describe('HTML5 Context Parser with Buggy Subclass Prototype', function(){
 
         it('should not print char twice in reconsume logic test', function(){
@@ -27,7 +33,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
                 }
                 this.bytes[i] = ch;
             };
-            var parser = new BuggyParser();
+            var parser = new BuggyParser(config);
             var data = fs.readFileSync(file, 'utf-8');
             parser.contextualize(data);
             o = parser.bytes.join('');
@@ -45,7 +51,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             BuggyParser.prototype.beforeWalk = function( ) {
                 return 1000;
             }
-            var parser = new BuggyParser();
+            var parser = new BuggyParser(config);
             parser.contextualize('<html></html>');
 
         });
@@ -58,7 +64,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             BuggyParser.prototype.walk = function( ) {
                 return 1000;
             }
-            var parser = new BuggyParser();
+            var parser = new BuggyParser(config);
             parser.contextualize('<html></html>');
 
         });

--- a/tests/unit/run-functions-spec.js
+++ b/tests/unit/run-functions-spec.js
@@ -15,11 +15,17 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         Parser = require("../../src/context-parser").Parser,
         FastParser = require("../../src/context-parser").FastParser;
 
+    var config = {
+        disableInputPreProcessing: false,
+        disableCanonicalization: false,
+        disableIEConditionalComments: false
+    };
+
     describe('HTML5 Context Parser Functions', function() {
 
         describe('#getStates', function(){
             it('should parse <html></html>', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 var html = "<html></html>";
                 p1.contextualize(html);
                 var states = p1.getStates();
@@ -29,14 +35,14 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
         describe('#setCurrentState', function(){
             it('should exist)', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 p1.setCurrentState(10);
             });
         });
         describe('#setInitState and #getInitState', function(){
 
             it('should exist and set state', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 p1.setInitState(10);
                 var state = p1.getInitState();
                 assert.equal(state, 10);
@@ -44,7 +50,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
 
             it('should get state', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 var html = "<html></html>";
                 p1.contextualize(html);
                 var state = p1.getInitState();
@@ -55,7 +61,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         describe('#getLastState', function(){
 
             it('should get last state', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 var html = "<html></html>";
                 p1.contextualize(html);
                 var state = p1.getLastState();
@@ -67,28 +73,28 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
             var html;
             it('should get attribute name following with quoted attribute value', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 html = "<div class='classname'></div>";
                 p1.contextualize(html);
                 assert.equal(p1.getAttributeName(), 'class');
             });
 
             it('should get attribute name following with double quoted attribute value', function(){
-                var p2 = new Parser();
+                var p2 = new Parser(config);
                 html = '<div class="classname"></div>';
                 p2.contextualize(html);
                 assert.equal(p2.getAttributeName(), 'class');
             });
 
             it('should get attribute name following with unquoted attribute value', function(){
-                var p3 = new Parser();
+                var p3 = new Parser(config);
                 html = "<div class=classname></div>";
                 p3.contextualize(html);
                 assert.equal(p3.getAttributeName(), 'class');
             });
 
             it('should get second attribute name', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 html = "<div class='classname' style='color:red'></div>";
                 p1.contextualize(html);
                 assert.equal(p1.getAttributeName(), 'style');
@@ -96,7 +102,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
             it('should get second attribute name (double quoted attribute value)', function(){
 
-                var p2 = new Parser();
+                var p2 = new Parser(config);
                 html = "<div class='classname' style=\"color:red\"></div>";
                 p2.contextualize(html);
                 assert.equal(p2.getAttributeName(), 'style');
@@ -104,7 +110,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
             it('should get second attribute name (unquoted attribute value)', function(){
 
-                var p3 = new Parser();
+                var p3 = new Parser(config);
                 html = "<div class='classname' style=color:red></div>";
                 p3.contextualize(html);
                 assert.equal(p3.getAttributeName(), 'style');
@@ -113,19 +119,19 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         describe('#getAttributeValue', function(){
 
             it('should get attribute value (quoted)', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 var html = "<div class='classname'></div>";
                 p1.contextualize(html);
                 assert.equal(p1.getAttributeValue(), 'classname');
             });
             it('should get attribute value (double quoted)', function(){
-                var p2 = new Parser();
+                var p2 = new Parser(config);
                 var html = '<div class="classname"></div>';
                 p2.contextualize(html);
                 assert.equal(p2.getAttributeValue(), 'classname');
             });
             it('should get attribute value (unquoted)', function(){
-                var p3 = new Parser();
+                var p3 = new Parser(config);
                 var html = "<div class=classname></div>";
                 p3.contextualize(html);
                 assert.equal(p3.getAttributeValue(), 'classname');
@@ -133,21 +139,21 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
 
             it('should get 2nd attribute value', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 var html = "<div class='classname' style='color:red'></div>";
                 p1.contextualize(html);
                 assert.equal(p1.getAttributeValue(), 'color:red');
             });
 
             it('should get 2nd attribute value (double quoted)', function(){
-                var p2 = new Parser();
+                var p2 = new Parser(config);
                 var html = '<div class="classname" style="color:red"></div>';
                 p2.contextualize(html);
                 assert.equal(p2.getAttributeValue(), 'color:red');
             });
 
             it('should get 2nd attribute value (unquoted)', function(){
-                var p3 = new Parser();
+                var p3 = new Parser(config);
                 var html = "<div class=classname style=color:red></div>";
                 p3.contextualize(html);
                 assert.equal(p3.getAttributeValue(), 'color:red');
@@ -156,7 +162,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
         describe('#lookupChar', function(){
             it('should match symbol lookup table', function(){
-                var parser = new Parser();
+                var parser = new Parser(config);
                 var r = parser.lookupChar('\t');
                 assert.equal(r, 0);
                 r = parser.lookupChar('\n');
@@ -201,7 +207,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         describe('#getStartTagName', function(){
 
             it('should return start tag name', function(){
-                var p1 = new Parser();
+                var p1 = new Parser(config);
                 var html = "<div class='classname' style='color:red'></div>";
                 p1.contextualize(html);
                 assert.equal(p1.getStartTagName(), 'div');
@@ -216,8 +222,8 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
                 var p1 = new Object();
                 var p2 = p1;
                 assert.equal(p1, p2);
-                var p1 = new Parser();
-                var p2 = new Parser();
+                var p1 = new Parser(config);
+                var p2 = new Parser(config);
                 if (p1 == p2) {
                     expect(false).to.equal(true);
                 } else {
@@ -230,7 +236,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
     describe('HTML5 Context Fast Parser', function() {
 
         it('should contextualize an open tag should end with open tag state', function(){
-            var fastParser = new FastParser();
+            var fastParser = new FastParser(config);
             var html = "<html> 1 < 2";
             fastParser.contextualize(html);
             expect(fastParser.state, 10)

--- a/tests/unit/run-functions-spec.js
+++ b/tests/unit/run-functions-spec.js
@@ -16,9 +16,9 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         FastParser = require("../../src/context-parser").FastParser;
 
     var config = {
-        disableInputPreProcessing: false,
-        disableCanonicalization: false,
-        disableIEConditionalComments: false
+        enableInputPreProcessing: false,
+        enableCanonicalization: false,
+        enableIEConditionalComments: false
     };
 
     describe('HTML5 Context Parser Functions', function() {

--- a/tests/unit/run-states-spec.js
+++ b/tests/unit/run-states-spec.js
@@ -13,11 +13,17 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
     var assert = require("assert"),
         Parser = require("../../src/context-parser").Parser;
 
+    var config = {
+        disableInputPreProcessing: false,
+        disableCanonicalization: false,
+        disableIEConditionalComments: false
+    };
+
     describe('HTML5 Context Parser StateMachine', function() {
 
         // https://html.spec.whatwg.org/multipage/syntax.html#tokenization
         it('should parse <html>{}</html>', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = "<html>{}</html>";
             p1.contextualize(html);
             var states = p1.getStates();
@@ -25,7 +31,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse attribute name', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = "<option value='1' selected >";
             p1.contextualize(html);
             var states = p1.getStates();
@@ -33,7 +39,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse double quoted attribute value', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<div class="classname" style="stylestring"></div>';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -41,7 +47,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse single quoted attribute value', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = "<div class='classname' style='stylestring'></div>";
             p1.contextualize(html);
             var states = p1.getStates();
@@ -49,7 +55,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse unquoted attribute value', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = "<div class= classname style= stylestring ></div>";
             p1.contextualize(html);
             var states = p1.getStates();
@@ -57,7 +63,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse slash double quoted attribute value', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<a href="javascript:alert(\"1\");">link</a>';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -65,7 +71,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse rcdata (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
 
             var html = '<html><title>title</title></html>';
             p1.contextualize(html);
@@ -80,7 +86,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse rcdata with space end tag (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<html><title>title</title ></html>';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -88,7 +94,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse double slash in rcdata end tag (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
 
             var html = '<html><title>title</title/></html>';
             p1.contextualize(html);
@@ -97,7 +103,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse <script> tag (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<script>var a = 0;</script>';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -105,7 +111,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse <script> with space end tag (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<script>var a = 0;</script >';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -113,7 +119,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse double slash in <script> end tag (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<script>var a = 0;</script/>';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -121,7 +127,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse <style> tag (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<style>style</style>';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -129,7 +135,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse <style> with space end tag (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<style>style</style >';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -137,7 +143,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse double slash in <style> end tag (extra logic:6)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<style>style</style/>';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -145,19 +151,19 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse <script> comment (extra logic:8)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<script><!-- script --> script data</script>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,10,10,6,17,20,21,24,22,22,22,22,22,22,22,22,23,24,6,6,6,6,6,6,6,6,6,6,6,6,6,17,18,19,19,19,19,19,19,1');
 
-            p1 = new Parser();
+            p1 = new Parser(config);
             var html = '<script><!-- <script --> script data</script>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,10,10,6,17,20,21,24,22,25,28,28,28,28,28,28,29,30,31,6,6,6,6,6,6,6,6,6,6,6,6,6,17,18,19,19,19,19,19,19,1');
 
-            p1 = new Parser();
+            p1 = new Parser(config);
             var html = '<script><!-- <abcde> --> script data</script>';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -166,7 +172,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse comment tag (extra logic:10)', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<!--comment-->';
             p1.contextualize(html);
             var states = p1.getStates();
@@ -174,49 +180,49 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         it('should parse extra logic 11', function(){
-            var p1 = new Parser();
+            var p1 = new Parser(config);
             var html = '<script>var a = 0;</script>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,10,10,6,6,6,6,6,6,6,6,6,6,6,17,18,19,19,19,19,19,19,1');
-            p1 = new Parser();
+            p1 = new Parser(config);
             html = '<noframes>noframes</noframes>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,10,10,10,10,5,5,5,5,5,5,5,5,5,14,15,16,16,16,16,16,16,16,16,1');
 
-            p1 = new Parser();
+            p1 = new Parser(config);
             html = '<xmp>xmptext</xmp>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,5,5,5,5,5,5,5,5,14,15,16,16,16,1');
 
-            p1 = new Parser();
+            p1 = new Parser(config);
             html = '<iframe></iframe>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,10,10,5,14,15,16,16,16,16,16,16,1');
 
-            p1 = new Parser();
+            p1 = new Parser(config);
             html = '<noembed></noembed>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,10,10,10,5,14,15,16,16,16,16,16,16,16,1');
 
-            p1 = new Parser();
+            p1 = new Parser(config);
             html = '<noscript></noscript>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,10,10,10,10,5,14,15,16,16,16,16,16,16,16,16,1');
 
-            p1 = new Parser();
+            p1 = new Parser(config);
             html = '<textarea></textarea>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,10,10,10,10,3,11,12,13,13,13,13,13,13,13,13,1');
 
             /* reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/plaintext */
-            p1 = new Parser();
+            p1 = new Parser(config);
             html = '<plaintext></plaintext>';
             p1.contextualize(html);
             var states = p1.getStates();

--- a/tests/unit/run-states-spec.js
+++ b/tests/unit/run-states-spec.js
@@ -14,9 +14,9 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         Parser = require("../../src/context-parser").Parser;
 
     var config = {
-        disableInputPreProcessing: false,
-        disableCanonicalization: false,
-        disableIEConditionalComments: false
+        enableInputPreProcessing: false,
+        enableCanonicalization: false,
+        enableIEConditionalComments: false
     };
 
     describe('HTML5 Context Parser StateMachine', function() {

--- a/tests/unit/run-states-spec.js
+++ b/tests/unit/run-states-spec.js
@@ -70,19 +70,22 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             assert.equal(states.toString(), '1,8,10,34,35,35,35,35,37,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,34,35,35,35,35,35,1,1,1,1,1,8,9,10,1');
         });
 
-        it('should parse rcdata (extra logic:6)', function(){
+        it('should parse rcdata 1 (extra logic:6)', function(){
             var p1 = new Parser(config);
 
             var html = '<html><title>title</title></html>';
             p1.contextualize(html);
             var states = p1.getStates();
             assert.equal(states.toString(), '1,8,10,10,10,10,1,8,10,10,10,10,10,3,3,3,3,3,3,11,12,13,13,13,13,13,1,8,9,10,10,10,10,1');
+        });
+
+        it('should parse rcdata 2 (extra logic:6)', function(){
+            var p1 = new Parser(config);
 
             var html = '<html><title>title</foo></title></html>';
             p1.contextualize(html);
             var states = p1.getStates();    
             assert.equal(states.toString(), '1,8,10,10,10,10,1,8,10,10,10,10,10,3,3,3,3,3,3,11,12,13,13,3,3,11,12,13,13,13,13,13,1,8,9,10,10,10,10,1');
-
         });
 
         it('should parse rcdata with space end tag (extra logic:6)', function(){

--- a/tests/unit/run-strict-context-parser.js
+++ b/tests/unit/run-strict-context-parser.js
@@ -1,0 +1,457 @@
+/*
+Copyright (c) 2015, Yahoo Inc. All rights reserved.
+Copyrights licensed under the New BSD License.
+See the accompanying LICENSE file for terms.
+
+Authors: Nera Liu <neraliu@yahoo-inc.com>
+         Albert Yu <albertyu@yahoo-inc.com>
+         Adonis Fung <adon@yahoo-inc.com>
+*/
+(function () {
+
+    require("mocha");
+    var config = {
+        disableInputPreProcessing: true,
+        disableCanonicalization: true,
+        disableIEConditionalComments: true
+    };
+    var expect = require('chai').expect,
+        ContextParser = require("../../src/context-parser.js").Parser,
+        contextParser = new ContextParser(config);
+
+    describe('Input Stream Pre-processing Test', function(){
+        it('\\r\\n treatment', function () {
+            expect(contextParser.parsePartial('\r\n')).to.equal('\n');
+            expect(contextParser.parsePartial('\r\r\r')).to.equal('\n\n\n');
+        });
+        it('control character \\x0B treatment', function () {
+            expect(contextParser.parsePartial('\x0B')).to.equal('\uFFFD');
+        });
+        it('unicode non-character U+1FFFF and U+1FFFE treatment', function () {
+            expect(contextParser.parsePartial('\uD83F\uDFFE')).to.equal('\uFFFD\uFFFD');  //U+1FFFE
+            expect(contextParser.parsePartial('\uD83F\uDFFF')).to.equal('\uFFFD\uFFFD');  //U+1FFFF
+        });
+    });
+
+    describe("HTML Partials", function() {
+        it("Inherit internal states from last partial parsing ", function() {
+            var html = ['<a href=', '{{url}}', '>hello</a>'],
+                htmlStates1, htmlStates3;
+                contextParser1 = new ContextParser(config);
+
+            expect(contextParser1.parsePartial(html[0])).to.equal('<a href=');
+            // StateMachine.State.STATE_BEFORE_ATTRIBUTE_VALUE = 37;
+            expect(contextParser1.getCurrentState()).to.equal(37);
+
+            // hardcode STATE_ATTRIBUTE_VALUE_UNQUOTED
+            contextParser1.setCurrentState(40);
+
+            contextParser1.parsePartial(html[2][0]);
+            // confirm state switched to STATE_DATA
+            expect(contextParser1.getCurrentState()).to.equal(1);
+
+            expect(contextParser1.parsePartial(html[2].slice(1))).to.equal('hello</a>');
+
+        });
+
+        it("bogus comment conversion", function() {
+            expect(contextParser.parsePartial('</>')).to.equal('<!--/-->');
+            expect(contextParser.parsePartial('<?>')).to.equal('<!--?-->');
+            expect(contextParser.parsePartial('<!>')).to.equal('<!--!-->');
+            expect(contextParser.parsePartial('<!->')).to.equal('<!--!--->');
+
+            // the following does not require transforming into comment
+            expect(contextParser.parsePartial('<%>')).to.equal('&lt;%>');
+            expect(contextParser.parsePartial('<3>')).to.equal('&lt;3>');
+        });
+
+        it("bogus comment conversion skipped", function() {
+            var contextParser = new ContextParser(config);
+
+            var html = ['</', '>'];
+            expect(contextParser.parsePartial(html[0])).to.equal('</');
+            expect(contextParser.parsePartial(html[1])).to.equal('>');
+
+            var html = ['<?', '?>'];
+            expect(contextParser.parsePartial(html[0])).to.equal('<!--?');
+            expect(contextParser.parsePartial(html[1])).to.equal('?-->');
+
+            var html = ['<!', '>'];
+            expect(contextParser.parsePartial(html[0])).to.equal('<!--!');
+            expect(contextParser.parsePartial(html[1])).to.equal('-->');
+
+            var html = ['<!-', '>'];
+            expect(contextParser.parsePartial(html[0])).to.equal('<!--!-');
+            expect(contextParser.parsePartial(html[1])).to.equal('-->');
+
+            delete contextParser;
+        });
+
+        it("bogus comment attacks", function() {
+
+            // https://html5sec.org/#91
+            var html = [
+                '<? foo="><script>alert(1)</script>">',
+                '<! foo="><script>alert(1)</script>">',
+                '</ foo="><script>alert(1)</script>">',
+                '<? foo="><x foo=\'?><script>alert(1)</script>\'>">',
+                '<! foo="[[[x]]"><x foo="]foo><script>alert(1)</script>">',
+                '<% foo><x foo="%><script>alert(1)</script>">'
+            ];
+
+            expect(contextParser.parsePartial(html[0])).to.equal('<!--? foo="--><script>alert(1)</script>">');
+            expect(contextParser.parsePartial(html[1])).to.equal('<!--! foo="--><script>alert(1)</script>">');
+            expect(contextParser.parsePartial(html[2])).to.equal('<!--/ foo="--><script>alert(1)</script>">');
+
+            expect(contextParser.parsePartial(html[3])).to.equal('<!--? foo="--><x foo=\'?><script>alert(1)</script>\'>">');
+            expect(contextParser.parsePartial(html[4])).to.equal('<!--! foo="[[[x]]"--><x foo="]foo><script>alert(1)</script>">');
+            expect(contextParser.parsePartial(html[5])).to.equal('&lt;% foo><x foo="%><script>alert(1)</script>">');
+        });
+
+        it("bogus comment conversion with two parsePartial calls (listeners inherited)", function() {
+            var html = ['<?yo', 'yo?>'];
+            var contextParser = new ContextParser(config);
+            expect(contextParser.parsePartial(html[0])).to.equal('<!--?yo');
+            expect(contextParser.parsePartial(html[1])).to.equal('yo?-->');
+            delete contextParser;
+        });
+
+        it("bogus comment conversion with forked ContextParser", function() {
+            var html = ['<?yo', 'yo?>'];
+            var contextParser = new ContextParser(config);
+            expect(contextParser.parsePartial(html[0])).to.equal('<!--?yo');
+
+            var contextParser1 = contextParser.fork();
+            expect(contextParser1.parsePartial(html[1])).to.equal('yo?-->');
+            delete contextParser, contextParser1;
+        });
+    });
+
+    describe("Comment Precedence in RAWTEXT and RCDATA", function() {
+        it("<% treatment", function() {
+            expect(contextParser.parsePartial('<style> <% </style> %> </style>')).to.equal('<style> &lt;% </style> %> </style>');
+            expect(contextParser.parsePartial('<textarea> <% </textarea> %> </textarea>')).to.equal('<textarea> &lt;% </textarea> %> </textarea>');
+        });
+        it("<! treatment", function() {
+            expect(contextParser.parsePartial('<style> <!-- </style> --> </style>')).to.equal('<style> &lt;!-- </style> --> </style>');
+            expect(contextParser.parsePartial('<textarea> <!-- </textarea> --> </textarea>')).to.equal('<textarea> &lt;!-- </textarea> --> </textarea>');
+        });
+    });
+
+    describe("Parse Error Correction in DATA", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('\x00')).to.equal('\uFFFD');
+        });
+    });
+
+    describe("Parse Error Correction in RCDATA", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<title>\x00</title>')).to.equal('<title>\uFFFD</title>');
+        });
+    });
+
+    describe("Parse Error Correction in RAWTEXT", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<style>\x00</style>')).to.equal('<style>\uFFFD</style>');
+        });
+    });
+
+    describe("Parse Error Correction in SCRIPT DATA", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<script>\x00</script>')).to.equal('<script>\uFFFD</script>');
+        });
+    });
+
+    describe("Parse Error Correction in PLAINTEXT", function() {
+        it("NULL treatment", function() {
+            expect(new ContextParser(config).parsePartial('<plaintext>\x00')).to.equal('<plaintext>\uFFFD');
+        });
+    });
+
+    describe("Parse Error Correction in TAG OPEN", function() {
+        it("QUESTION MARK treatment", function() {
+            expect(contextParser.parsePartial('abcd<?  ?>efgh')).to.equal('abcd<!--?  ?-->efgh');
+        });
+        it("ANYTHING ELSE treatment", function() {
+            expect(contextParser.parsePartial('abcd<\x00efgh')).to.equal('abcd&lt;\uFFFDefgh');
+            expect(contextParser.parsePartial('abcd<3<3<3efgh')).to.equal('abcd&lt;3&lt;3&lt;3efgh');
+            expect(contextParser.parsePartial('<<br>')).to.equal('&lt;<br>');
+        });
+    });
+
+    describe("Parse Error Correction in END TAG OPEN", function() {
+        it("GREATER-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('abcd</>efgh')).to.equal('abcd<!--/-->efgh');
+        });
+        it("ANYTHING ELSE treatment", function() {
+            expect(contextParser.parsePartial('abcd</\x00div>efgh')).to.equal('abcd<!--/\uFFFDdiv-->efgh');
+            expect(contextParser.parsePartial('abcd</ div>efgh')).to.equal('abcd<!--/ div-->efgh');
+        });
+    });
+
+    describe("Parse Error Correction in TAG NAME", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<b\x00r><b\x00r/>')).to.equal('<b\uFFFDr><b\uFFFDr/>');
+        });
+    });
+
+
+    describe("Parse Error Correction in SCRIPT DATA ESCAPED", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<script><!-- \x00 --></script>')).to.equal('<script><!-- \uFFFD --></script>');
+        });
+    });
+
+    describe("Parse Error Correction in SCRIPT DATA ESCAPED DASH", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<script><!-- -\x00 --></script>')).to.equal('<script><!-- -\uFFFD --></script>');
+        });
+    });
+
+    describe("Parse Error Correction in SCRIPT DATA ESCAPED DASH DASH", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<script><!-- --\x00 --></script>')).to.equal('<script><!-- --\uFFFD --></script>');
+        });
+    });
+
+    describe("Parse Error Correction in SCRIPT DATA DOUBLE ESCAPED", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<script><!-- <script>\x00 --></script>')).to.equal('<script><!-- <script>\uFFFD --></script>');
+        });
+    });
+
+    describe("Parse Error Correction in SCRIPT DATA DOUBLE ESCAPED DASH", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<script><!-- <script> -\x00 --></script>')).to.equal('<script><!-- <script> -\uFFFD --></script>');
+        });
+    });
+
+    describe("Parse Error Correction in SCRIPT DATA DOUBLE ESCAPED DASH DASH", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<script><!-- <script> --\x00 --></script>')).to.equal('<script><!-- <script> --\uFFFD --></script>');
+        });
+    });
+
+    describe("Parse Error Correction in BEFORE ATTRIBUTE NAME", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<a \x00href="#">hello</a>')).to.equal('<a \uFFFDhref="#">hello</a>');
+        });
+        it("QUOTATION MARK treatment", function() {
+            expect(contextParser.parsePartial('<a "href="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.parsePartial('<img src="x" "b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.parsePartial('<img src="x""b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+        });
+        it("APOSTROPHE treatment", function() {
+            expect(contextParser.parsePartial('<a \'href="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.parsePartial('<img src="x" \'b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.parsePartial('<img src="x"\'b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+        });
+        it("LESS-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a <href="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.parsePartial('<img src="x" <b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.parsePartial('<img src="x"<b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+        });
+        it("EQUALS SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a =href="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.parsePartial('<img src="x" =b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.parsePartial('<img src="x"=b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+        });
+    });
+
+    describe("Parse Error Correction in ATTRIBUTE NAME", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<a hre\x00f="#">hello</a>')).to.equal('<a hre\uFFFDf="#">hello</a>');
+        });
+        it("QUOTATION MARK treatment", function() {
+            expect(contextParser.parsePartial('<a href"="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.parsePartial('<a href"="#">hello</a>')).to.equal('<a href="#">hello</a>');
+        });
+        it("APOSTROPHE treatment", function() {
+            expect(contextParser.parsePartial('<a href\'="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.parsePartial('<a href\'="#">hello</a>')).to.equal('<a href="#">hello</a>');
+        });
+        it("LESS-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a href<="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.parsePartial('<a href<="#">hello</a>')).to.equal('<a href="#">hello</a>');
+        });
+
+
+        it("malicious attribute names using APOSTROPHE", function() {
+
+            // https://html5sec.org/#62
+            var html = [
+                '<!-- IE 6-8 --><x \'="foo"><x foo=\'><img src=x onerror=alert(1)//\'>', 
+                '<!-- IE 6-9 --><! \'="foo"><x foo=\'><img src=x onerror=alert(2)//\'>',
+                '<!-- IE 6-9 --><? \'="foo"><x foo=\'><img src=x onerror=alert(3)//\'>'
+            ];
+
+            expect(contextParser.parsePartial(html[0])).to.equal('<!-- IE 6-8 --><x foo><x foo=\'><img src=x onerror=alert(1)//\'>');
+            expect(contextParser.parsePartial(html[1])).to.equal('<!-- IE 6-9 --><!--! \'="foo"--><x foo=\'><img src=x onerror=alert(2)//\'>');
+            expect(contextParser.parsePartial(html[2])).to.equal('<!-- IE 6-9 --><!--? \'="foo"--><x foo=\'><img src=x onerror=alert(3)//\'>');
+        });
+    });
+
+    describe("Parse Error Correction in AFTER ATTRIBUTE NAME", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<a href \x00="#">hello</a>')).to.equal('<a href \uFFFD="#">hello</a>');
+        });
+        it("QUOTATION MARK treatment", function() {
+            expect(contextParser.parsePartial('<a href "="#">hello</a>')).to.equal('<a href ="#">hello</a>');
+        });
+        it("APOSTROPHE treatment", function() {
+            expect(contextParser.parsePartial('<a href \'="#">hello</a>')).to.equal('<a href ="#">hello</a>');
+        });
+        it("LESS-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a href <="#">hello</a>')).to.equal('<a href ="#">hello</a>');
+        });
+    });
+
+    describe("Parse Error Correction in BEFORE ATTRIBUTE VALUE", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<a href=\x00x>hello</a>')).to.equal('<a href=\uFFFDx>hello</a>');
+        });
+        it("GREATER-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a href=>hello</a>')).to.equal('<a href>hello</a>');
+        });
+        it("LESS-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a href=<x>hello</a>')).to.equal('<a href=&lt;x>hello</a>');
+            expect(contextParser.parsePartial('<a href=<>hello</a>')).to.equal('<a href=&lt;>hello</a>');
+        });
+        it("EQUALS SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a href==x>hello</a>')).to.equal('<a href=&#61;x>hello</a>');
+            expect(contextParser.parsePartial('<a href==>hello</a>')).to.equal('<a href=&#61;>hello</a>');
+        });
+        it("GRAVE ACCENT treatment", function() {
+            expect(contextParser.parsePartial('<a href=`x`>hello</a>')).to.equal('<a href=&#96;x&#96;>hello</a>');
+            expect(contextParser.parsePartial('<a href=`>hello</a>')).to.equal('<a href=&#96;>hello</a>');
+        });
+    });
+
+    describe("Parse Error Correction in ATTRIBUTE VALUE (DOUBLE-QUOTED)", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<a href="\x00">hello</a>')).to.equal('<a href="\uFFFD">hello</a>');
+        });
+    });
+
+    describe("Parse Error Correction in ATTRIBUTE VALUE (SINGLE-QUOTED)", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<a href=\'\x00\'>hello</a>')).to.equal('<a href=\'\uFFFD\'>hello</a>');
+        });
+    });
+
+    describe("Parse Error Correction in ATTRIBUTE VALUE (UNQUOTED)", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<a href=x\x00>hello</a>')).to.equal('<a href=x\uFFFD>hello</a>');
+        });
+        it("QUOTATION MARK treatment", function() {
+            expect(contextParser.parsePartial('<a href=x">hello</a>')).to.equal('<a href=x&quot;>hello</a>');
+        });
+        it("APOSTROPHE treatment", function() {
+            expect(contextParser.parsePartial('<a href=x\'>hello</a>')).to.equal('<a href=x&#39;>hello</a>');
+        });
+        it("LESS-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a href=x<>hello</a>')).to.equal('<a href=x&lt;>hello</a>');
+            expect(contextParser.parsePartial('<a href=<>hello</a>')).to.equal('<a href=&lt;>hello</a>');
+        });
+        it("EQUALS SIGN treatment", function() {
+            expect(contextParser.parsePartial('<a href=x=>hello</a>')).to.equal('<a href=x&#61;>hello</a>');
+            expect(contextParser.parsePartial('<a href==>hello</a>')).to.equal('<a href=&#61;>hello</a>');
+        });
+        it("GRAVE ACCENT treatment", function() {
+            expect(contextParser.parsePartial('<a href=x`>hello</a>')).to.equal('<a href=x&#96;>hello</a>');
+            expect(contextParser.parsePartial('<a href=`>hello</a>')).to.equal('<a href=&#96;>hello</a>');
+        });
+    });
+
+    describe("Parse Error Correction in AFTER ATTRIBUTE VALUE (QUOTED)", function() {
+        it("ANYTHING ELSE treatment", function() {
+            expect(contextParser.parsePartial('<img src="x" onclick=""/>')).to.equal('<img src="x" onclick=""/>');
+            expect(contextParser.parsePartial('<img src="x"onclick=""/>')).to.equal('<img src="x" onclick=""/>');
+        });
+    });
+
+    describe("Parse Error Correction in SELF-CLOSING START TAG", function() {
+        it("ANYTHING ELSE treatment", function() {
+            expect(contextParser.parsePartial('<br/ onclick="">')).to.equal('<br  onclick="">');
+            expect(contextParser.parsePartial('<br/onclick="">')).to.equal('<br onclick="">');
+
+            expect(contextParser.parsePartial('<br /onclick="">')).to.equal('<br  onclick="">');
+            expect(contextParser.parsePartial('<br oncl/ick="">')).to.equal('<br oncl ick="">');
+            expect(contextParser.parsePartial('<br onclick /="">')).to.equal('<br onclick  >');
+            expect(contextParser.parsePartial('<br onclick/="alert(1)">')).to.equal('<br onclick alert(1)>');
+            expect(contextParser.parsePartial('<br onclick /="alert(1)">')).to.equal('<br onclick  alert(1)>');
+        });
+    });
+
+    describe("Parse Error Correction in MARKUP DECLARATION OPEN", function() {
+        it("doctype treatment", function() {
+            expect(contextParser.parsePartial('<!doctype html>')).to.equal('<!doctype html>');
+            expect(contextParser.parsePartial('<!doctype html5>')).to.equal('<!--!doctype html5--><!doctype html>');
+            expect(contextParser.parsePartial('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">'))
+                .to.equal('<!--!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"--><!doctype html>');
+        });
+        it("[CDATA[ treatment", function() {
+            expect(contextParser.parsePartial('<math><ms><![CDATA[x<y]]></ms></math>')).to.equal('<math><ms><![CDATA[x<y]]></ms></math>');
+        });
+        it("standard comment treatment", function() {
+            expect(contextParser.parsePartial('<!--hello-->')).to.equal('<!--hello-->');
+        });
+    });
+
+    describe("Parse Error Correction in COMMENT START", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<!--\x00-->')).to.equal('<!--\uFFFD-->');
+        });
+        it("GREATER-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('<!-->')).to.equal('<!---->');
+        });
+    });
+
+    describe("Parse Error Correction in COMMENT START DASH", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<!---\x00-->')).to.equal('<!---\uFFFD-->');
+        });
+        it("GREATER-THAN SIGN treatment", function() {
+            expect(contextParser.parsePartial('<!--->')).to.equal('<!---->');
+        });
+
+    });
+
+    describe("Parse Error Correction in COMMENT", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<!-- \x00-->')).to.equal('<!-- \uFFFD-->');
+        });
+    });
+
+    describe("Parse Error Correction in COMMENT END DASH", function() {
+        it("NULL treatment", function() {
+            // expect(contextParser.parsePartial('<!---\x00->')).to.equal('<!---\uFFFD->');
+            expect(contextParser.parsePartial('<!---\x00>-->')).to.equal('<!---\uFFFD>-->');
+        });
+    });
+
+    describe("Parse Error Correction in COMMENT END", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<!----\x00>-->')).to.equal('<!----\uFFFD>-->');
+        });
+        it("EXCLAMATION MARK treatment", function() {
+            expect(contextParser.parsePartial('<!--abc--!>')).to.equal('<!--abc-->');
+            expect(contextParser.parsePartial('<!--abc--!-->')).to.equal('<!--abc--!-->');
+            expect(contextParser.parsePartial('<!--abc--! -->')).to.equal('<!--abc--! -->');
+            expect(contextParser.parsePartial('<!--abc--! --!>')).to.equal('<!--abc--! -->');
+        });
+        it("HYPHEN-MINUS treatment", function() {
+            expect(contextParser.parsePartial('<!--abc--->')).to.equal('<!--abc--->');
+        });
+        it("ANYTHING ELSE treatment", function() {
+            expect(contextParser.parsePartial('<!--abc--a-->')).to.equal('<!--abc--a-->');
+        });
+    });
+
+    describe("Parse Error Correction in COMMENT END BANG", function() {
+        it("NULL treatment", function() {
+            expect(contextParser.parsePartial('<!----!\x00>-->')).to.equal('<!----!\uFFFD>-->');
+        });
+    });
+
+}());

--- a/tests/unit/run-strict-context-parser.js
+++ b/tests/unit/run-strict-context-parser.js
@@ -11,9 +11,9 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
     require("mocha");
     var config = {
-        disableInputPreProcessing: true,
-        disableCanonicalization: true,
-        disableIEConditionalComments: true
+        enableInputPreProcessing: true,
+        enableCanonicalization: true,
+        enableIEConditionalComments: true
     };
     var expect = require('chai').expect,
         ContextParser = require("../../src/context-parser.js").Parser,
@@ -21,15 +21,15 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
     describe('Input Stream Pre-processing Test', function(){
         it('\\r\\n treatment', function () {
-            expect(contextParser.parsePartial('\r\n')).to.equal('\n');
-            expect(contextParser.parsePartial('\r\r\r')).to.equal('\n\n\n');
+            expect(contextParser.contextualize('\r\n')).to.equal('\n');
+            expect(contextParser.contextualize('\r\r\r')).to.equal('\n\n\n');
         });
         it('control character \\x0B treatment', function () {
-            expect(contextParser.parsePartial('\x0B')).to.equal('\uFFFD');
+            expect(contextParser.contextualize('\x0B')).to.equal('\uFFFD');
         });
         it('unicode non-character U+1FFFF and U+1FFFE treatment', function () {
-            expect(contextParser.parsePartial('\uD83F\uDFFE')).to.equal('\uFFFD\uFFFD');  //U+1FFFE
-            expect(contextParser.parsePartial('\uD83F\uDFFF')).to.equal('\uFFFD\uFFFD');  //U+1FFFF
+            expect(contextParser.contextualize('\uD83F\uDFFE')).to.equal('\uFFFD\uFFFD');  //U+1FFFE
+            expect(contextParser.contextualize('\uD83F\uDFFF')).to.equal('\uFFFD\uFFFD');  //U+1FFFF
         });
     });
 
@@ -39,50 +39,50 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
                 htmlStates1, htmlStates3;
                 contextParser1 = new ContextParser(config);
 
-            expect(contextParser1.parsePartial(html[0])).to.equal('<a href=');
+            expect(contextParser1.contextualize(html[0])).to.equal('<a href=');
             // StateMachine.State.STATE_BEFORE_ATTRIBUTE_VALUE = 37;
             expect(contextParser1.getCurrentState()).to.equal(37);
 
             // hardcode STATE_ATTRIBUTE_VALUE_UNQUOTED
             contextParser1.setCurrentState(40);
 
-            contextParser1.parsePartial(html[2][0]);
+            contextParser1.contextualize(html[2][0]);
             // confirm state switched to STATE_DATA
             expect(contextParser1.getCurrentState()).to.equal(1);
 
-            expect(contextParser1.parsePartial(html[2].slice(1))).to.equal('hello</a>');
+            expect(contextParser1.contextualize(html[2].slice(1))).to.equal('hello</a>');
 
         });
 
         it("bogus comment conversion", function() {
-            expect(contextParser.parsePartial('</>')).to.equal('<!--/-->');
-            expect(contextParser.parsePartial('<?>')).to.equal('<!--?-->');
-            expect(contextParser.parsePartial('<!>')).to.equal('<!--!-->');
-            expect(contextParser.parsePartial('<!->')).to.equal('<!--!--->');
+            expect(contextParser.contextualize('</>')).to.equal('<!--/-->');
+            expect(contextParser.contextualize('<?>')).to.equal('<!--?-->');
+            expect(contextParser.contextualize('<!>')).to.equal('<!--!-->');
+            expect(contextParser.contextualize('<!->')).to.equal('<!--!--->');
 
             // the following does not require transforming into comment
-            expect(contextParser.parsePartial('<%>')).to.equal('&lt;%>');
-            expect(contextParser.parsePartial('<3>')).to.equal('&lt;3>');
+            expect(contextParser.contextualize('<%>')).to.equal('&lt;%>');
+            expect(contextParser.contextualize('<3>')).to.equal('&lt;3>');
         });
 
         it("bogus comment conversion skipped", function() {
             var contextParser = new ContextParser(config);
 
             var html = ['</', '>'];
-            expect(contextParser.parsePartial(html[0])).to.equal('</');
-            expect(contextParser.parsePartial(html[1])).to.equal('>');
+            expect(contextParser.contextualize(html[0])).to.equal('</');
+            expect(contextParser.contextualize(html[1])).to.equal('>');
 
             var html = ['<?', '?>'];
-            expect(contextParser.parsePartial(html[0])).to.equal('<!--?');
-            expect(contextParser.parsePartial(html[1])).to.equal('?-->');
+            expect(contextParser.contextualize(html[0])).to.equal('<!--?');
+            expect(contextParser.contextualize(html[1])).to.equal('?-->');
 
             var html = ['<!', '>'];
-            expect(contextParser.parsePartial(html[0])).to.equal('<!--!');
-            expect(contextParser.parsePartial(html[1])).to.equal('-->');
+            expect(contextParser.contextualize(html[0])).to.equal('<!--!');
+            expect(contextParser.contextualize(html[1])).to.equal('-->');
 
             var html = ['<!-', '>'];
-            expect(contextParser.parsePartial(html[0])).to.equal('<!--!-');
-            expect(contextParser.parsePartial(html[1])).to.equal('-->');
+            expect(contextParser.contextualize(html[0])).to.equal('<!--!-');
+            expect(contextParser.contextualize(html[1])).to.equal('-->');
 
             delete contextParser;
         });
@@ -99,180 +99,180 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
                 '<% foo><x foo="%><script>alert(1)</script>">'
             ];
 
-            expect(contextParser.parsePartial(html[0])).to.equal('<!--? foo="--><script>alert(1)</script>">');
-            expect(contextParser.parsePartial(html[1])).to.equal('<!--! foo="--><script>alert(1)</script>">');
-            expect(contextParser.parsePartial(html[2])).to.equal('<!--/ foo="--><script>alert(1)</script>">');
+            expect(contextParser.contextualize(html[0])).to.equal('<!--? foo="--><script>alert(1)</script>">');
+            expect(contextParser.contextualize(html[1])).to.equal('<!--! foo="--><script>alert(1)</script>">');
+            expect(contextParser.contextualize(html[2])).to.equal('<!--/ foo="--><script>alert(1)</script>">');
 
-            expect(contextParser.parsePartial(html[3])).to.equal('<!--? foo="--><x foo=\'?><script>alert(1)</script>\'>">');
-            expect(contextParser.parsePartial(html[4])).to.equal('<!--! foo="[[[x]]"--><x foo="]foo><script>alert(1)</script>">');
-            expect(contextParser.parsePartial(html[5])).to.equal('&lt;% foo><x foo="%><script>alert(1)</script>">');
+            expect(contextParser.contextualize(html[3])).to.equal('<!--? foo="--><x foo=\'?><script>alert(1)</script>\'>">');
+            expect(contextParser.contextualize(html[4])).to.equal('<!--! foo="[[[x]]"--><x foo="]foo><script>alert(1)</script>">');
+            expect(contextParser.contextualize(html[5])).to.equal('&lt;% foo><x foo="%><script>alert(1)</script>">');
         });
 
-        it("bogus comment conversion with two parsePartial calls (listeners inherited)", function() {
+        it("bogus comment conversion with two contextualize calls (listeners inherited)", function() {
             var html = ['<?yo', 'yo?>'];
             var contextParser = new ContextParser(config);
-            expect(contextParser.parsePartial(html[0])).to.equal('<!--?yo');
-            expect(contextParser.parsePartial(html[1])).to.equal('yo?-->');
+            expect(contextParser.contextualize(html[0])).to.equal('<!--?yo');
+            expect(contextParser.contextualize(html[1])).to.equal('yo?-->');
             delete contextParser;
         });
 
         it("bogus comment conversion with forked ContextParser", function() {
             var html = ['<?yo', 'yo?>'];
             var contextParser = new ContextParser(config);
-            expect(contextParser.parsePartial(html[0])).to.equal('<!--?yo');
+            expect(contextParser.contextualize(html[0])).to.equal('<!--?yo');
 
             var contextParser1 = contextParser.fork();
-            expect(contextParser1.parsePartial(html[1])).to.equal('yo?-->');
+            expect(contextParser1.contextualize(html[1])).to.equal('yo?-->');
             delete contextParser, contextParser1;
         });
     });
 
     describe("Comment Precedence in RAWTEXT and RCDATA", function() {
         it("<% treatment", function() {
-            expect(contextParser.parsePartial('<style> <% </style> %> </style>')).to.equal('<style> &lt;% </style> %> </style>');
-            expect(contextParser.parsePartial('<textarea> <% </textarea> %> </textarea>')).to.equal('<textarea> &lt;% </textarea> %> </textarea>');
+            expect(contextParser.contextualize('<style> <% </style> %> </style>')).to.equal('<style> &lt;% </style> %> </style>');
+            expect(contextParser.contextualize('<textarea> <% </textarea> %> </textarea>')).to.equal('<textarea> &lt;% </textarea> %> </textarea>');
         });
         it("<! treatment", function() {
-            expect(contextParser.parsePartial('<style> <!-- </style> --> </style>')).to.equal('<style> &lt;!-- </style> --> </style>');
-            expect(contextParser.parsePartial('<textarea> <!-- </textarea> --> </textarea>')).to.equal('<textarea> &lt;!-- </textarea> --> </textarea>');
+            expect(contextParser.contextualize('<style> <!-- </style> --> </style>')).to.equal('<style> &lt;!-- </style> --> </style>');
+            expect(contextParser.contextualize('<textarea> <!-- </textarea> --> </textarea>')).to.equal('<textarea> &lt;!-- </textarea> --> </textarea>');
         });
     });
 
     describe("Parse Error Correction in DATA", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('\x00')).to.equal('\uFFFD');
+            expect(contextParser.contextualize('\x00')).to.equal('\uFFFD');
         });
     });
 
     describe("Parse Error Correction in RCDATA", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<title>\x00</title>')).to.equal('<title>\uFFFD</title>');
+            expect(contextParser.contextualize('<title>\x00</title>')).to.equal('<title>\uFFFD</title>');
         });
     });
 
     describe("Parse Error Correction in RAWTEXT", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<style>\x00</style>')).to.equal('<style>\uFFFD</style>');
+            expect(contextParser.contextualize('<style>\x00</style>')).to.equal('<style>\uFFFD</style>');
         });
     });
 
     describe("Parse Error Correction in SCRIPT DATA", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<script>\x00</script>')).to.equal('<script>\uFFFD</script>');
+            expect(contextParser.contextualize('<script>\x00</script>')).to.equal('<script>\uFFFD</script>');
         });
     });
 
     describe("Parse Error Correction in PLAINTEXT", function() {
         it("NULL treatment", function() {
-            expect(new ContextParser(config).parsePartial('<plaintext>\x00')).to.equal('<plaintext>\uFFFD');
+            expect(new ContextParser(config).contextualize('<plaintext>\x00')).to.equal('<plaintext>\uFFFD');
         });
     });
 
     describe("Parse Error Correction in TAG OPEN", function() {
         it("QUESTION MARK treatment", function() {
-            expect(contextParser.parsePartial('abcd<?  ?>efgh')).to.equal('abcd<!--?  ?-->efgh');
+            expect(contextParser.contextualize('abcd<?  ?>efgh')).to.equal('abcd<!--?  ?-->efgh');
         });
         it("ANYTHING ELSE treatment", function() {
-            expect(contextParser.parsePartial('abcd<\x00efgh')).to.equal('abcd&lt;\uFFFDefgh');
-            expect(contextParser.parsePartial('abcd<3<3<3efgh')).to.equal('abcd&lt;3&lt;3&lt;3efgh');
-            expect(contextParser.parsePartial('<<br>')).to.equal('&lt;<br>');
+            expect(contextParser.contextualize('abcd<\x00efgh')).to.equal('abcd&lt;\uFFFDefgh');
+            expect(contextParser.contextualize('abcd<3<3<3efgh')).to.equal('abcd&lt;3&lt;3&lt;3efgh');
+            expect(contextParser.contextualize('<<br>')).to.equal('&lt;<br>');
         });
     });
 
     describe("Parse Error Correction in END TAG OPEN", function() {
         it("GREATER-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('abcd</>efgh')).to.equal('abcd<!--/-->efgh');
+            expect(contextParser.contextualize('abcd</>efgh')).to.equal('abcd<!--/-->efgh');
         });
         it("ANYTHING ELSE treatment", function() {
-            expect(contextParser.parsePartial('abcd</\x00div>efgh')).to.equal('abcd<!--/\uFFFDdiv-->efgh');
-            expect(contextParser.parsePartial('abcd</ div>efgh')).to.equal('abcd<!--/ div-->efgh');
+            expect(contextParser.contextualize('abcd</\x00div>efgh')).to.equal('abcd<!--/\uFFFDdiv-->efgh');
+            expect(contextParser.contextualize('abcd</ div>efgh')).to.equal('abcd<!--/ div-->efgh');
         });
     });
 
     describe("Parse Error Correction in TAG NAME", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<b\x00r><b\x00r/>')).to.equal('<b\uFFFDr><b\uFFFDr/>');
+            expect(contextParser.contextualize('<b\x00r><b\x00r/>')).to.equal('<b\uFFFDr><b\uFFFDr/>');
         });
     });
 
 
     describe("Parse Error Correction in SCRIPT DATA ESCAPED", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<script><!-- \x00 --></script>')).to.equal('<script><!-- \uFFFD --></script>');
+            expect(contextParser.contextualize('<script><!-- \x00 --></script>')).to.equal('<script><!-- \uFFFD --></script>');
         });
     });
 
     describe("Parse Error Correction in SCRIPT DATA ESCAPED DASH", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<script><!-- -\x00 --></script>')).to.equal('<script><!-- -\uFFFD --></script>');
+            expect(contextParser.contextualize('<script><!-- -\x00 --></script>')).to.equal('<script><!-- -\uFFFD --></script>');
         });
     });
 
     describe("Parse Error Correction in SCRIPT DATA ESCAPED DASH DASH", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<script><!-- --\x00 --></script>')).to.equal('<script><!-- --\uFFFD --></script>');
+            expect(contextParser.contextualize('<script><!-- --\x00 --></script>')).to.equal('<script><!-- --\uFFFD --></script>');
         });
     });
 
     describe("Parse Error Correction in SCRIPT DATA DOUBLE ESCAPED", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<script><!-- <script>\x00 --></script>')).to.equal('<script><!-- <script>\uFFFD --></script>');
+            expect(contextParser.contextualize('<script><!-- <script>\x00 --></script>')).to.equal('<script><!-- <script>\uFFFD --></script>');
         });
     });
 
     describe("Parse Error Correction in SCRIPT DATA DOUBLE ESCAPED DASH", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<script><!-- <script> -\x00 --></script>')).to.equal('<script><!-- <script> -\uFFFD --></script>');
+            expect(contextParser.contextualize('<script><!-- <script> -\x00 --></script>')).to.equal('<script><!-- <script> -\uFFFD --></script>');
         });
     });
 
     describe("Parse Error Correction in SCRIPT DATA DOUBLE ESCAPED DASH DASH", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<script><!-- <script> --\x00 --></script>')).to.equal('<script><!-- <script> --\uFFFD --></script>');
+            expect(contextParser.contextualize('<script><!-- <script> --\x00 --></script>')).to.equal('<script><!-- <script> --\uFFFD --></script>');
         });
     });
 
     describe("Parse Error Correction in BEFORE ATTRIBUTE NAME", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<a \x00href="#">hello</a>')).to.equal('<a \uFFFDhref="#">hello</a>');
+            expect(contextParser.contextualize('<a \x00href="#">hello</a>')).to.equal('<a \uFFFDhref="#">hello</a>');
         });
         it("QUOTATION MARK treatment", function() {
-            expect(contextParser.parsePartial('<a "href="#">hello</a>')).to.equal('<a href="#">hello</a>');
-            expect(contextParser.parsePartial('<img src="x" "b>hello</b>')).to.equal('<img src="x" b>hello</b>');
-            expect(contextParser.parsePartial('<img src="x""b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.contextualize('<a "href="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<img src="x" "b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.contextualize('<img src="x""b>hello</b>')).to.equal('<img src="x" b>hello</b>');
         });
         it("APOSTROPHE treatment", function() {
-            expect(contextParser.parsePartial('<a \'href="#">hello</a>')).to.equal('<a href="#">hello</a>');
-            expect(contextParser.parsePartial('<img src="x" \'b>hello</b>')).to.equal('<img src="x" b>hello</b>');
-            expect(contextParser.parsePartial('<img src="x"\'b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.contextualize('<a \'href="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<img src="x" \'b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.contextualize('<img src="x"\'b>hello</b>')).to.equal('<img src="x" b>hello</b>');
         });
         it("LESS-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a <href="#">hello</a>')).to.equal('<a href="#">hello</a>');
-            expect(contextParser.parsePartial('<img src="x" <b>hello</b>')).to.equal('<img src="x" b>hello</b>');
-            expect(contextParser.parsePartial('<img src="x"<b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.contextualize('<a <href="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<img src="x" <b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.contextualize('<img src="x"<b>hello</b>')).to.equal('<img src="x" b>hello</b>');
         });
         it("EQUALS SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a =href="#">hello</a>')).to.equal('<a href="#">hello</a>');
-            expect(contextParser.parsePartial('<img src="x" =b>hello</b>')).to.equal('<img src="x" b>hello</b>');
-            expect(contextParser.parsePartial('<img src="x"=b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.contextualize('<a =href="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<img src="x" =b>hello</b>')).to.equal('<img src="x" b>hello</b>');
+            expect(contextParser.contextualize('<img src="x"=b>hello</b>')).to.equal('<img src="x" b>hello</b>');
         });
     });
 
     describe("Parse Error Correction in ATTRIBUTE NAME", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<a hre\x00f="#">hello</a>')).to.equal('<a hre\uFFFDf="#">hello</a>');
+            expect(contextParser.contextualize('<a hre\x00f="#">hello</a>')).to.equal('<a hre\uFFFDf="#">hello</a>');
         });
         it("QUOTATION MARK treatment", function() {
-            expect(contextParser.parsePartial('<a href"="#">hello</a>')).to.equal('<a href="#">hello</a>');
-            expect(contextParser.parsePartial('<a href"="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<a href"="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<a href"="#">hello</a>')).to.equal('<a href="#">hello</a>');
         });
         it("APOSTROPHE treatment", function() {
-            expect(contextParser.parsePartial('<a href\'="#">hello</a>')).to.equal('<a href="#">hello</a>');
-            expect(contextParser.parsePartial('<a href\'="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<a href\'="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<a href\'="#">hello</a>')).to.equal('<a href="#">hello</a>');
         });
         it("LESS-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a href<="#">hello</a>')).to.equal('<a href="#">hello</a>');
-            expect(contextParser.parsePartial('<a href<="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<a href<="#">hello</a>')).to.equal('<a href="#">hello</a>');
+            expect(contextParser.contextualize('<a href<="#">hello</a>')).to.equal('<a href="#">hello</a>');
         });
 
 
@@ -285,172 +285,172 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
                 '<!-- IE 6-9 --><? \'="foo"><x foo=\'><img src=x onerror=alert(3)//\'>'
             ];
 
-            expect(contextParser.parsePartial(html[0])).to.equal('<!-- IE 6-8 --><x foo><x foo=\'><img src=x onerror=alert(1)//\'>');
-            expect(contextParser.parsePartial(html[1])).to.equal('<!-- IE 6-9 --><!--! \'="foo"--><x foo=\'><img src=x onerror=alert(2)//\'>');
-            expect(contextParser.parsePartial(html[2])).to.equal('<!-- IE 6-9 --><!--? \'="foo"--><x foo=\'><img src=x onerror=alert(3)//\'>');
+            expect(contextParser.contextualize(html[0])).to.equal('<!-- IE 6-8 --><x foo><x foo=\'><img src=x onerror=alert(1)//\'>');
+            expect(contextParser.contextualize(html[1])).to.equal('<!-- IE 6-9 --><!--! \'="foo"--><x foo=\'><img src=x onerror=alert(2)//\'>');
+            expect(contextParser.contextualize(html[2])).to.equal('<!-- IE 6-9 --><!--? \'="foo"--><x foo=\'><img src=x onerror=alert(3)//\'>');
         });
     });
 
     describe("Parse Error Correction in AFTER ATTRIBUTE NAME", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<a href \x00="#">hello</a>')).to.equal('<a href \uFFFD="#">hello</a>');
+            expect(contextParser.contextualize('<a href \x00="#">hello</a>')).to.equal('<a href \uFFFD="#">hello</a>');
         });
         it("QUOTATION MARK treatment", function() {
-            expect(contextParser.parsePartial('<a href "="#">hello</a>')).to.equal('<a href ="#">hello</a>');
+            expect(contextParser.contextualize('<a href "="#">hello</a>')).to.equal('<a href ="#">hello</a>');
         });
         it("APOSTROPHE treatment", function() {
-            expect(contextParser.parsePartial('<a href \'="#">hello</a>')).to.equal('<a href ="#">hello</a>');
+            expect(contextParser.contextualize('<a href \'="#">hello</a>')).to.equal('<a href ="#">hello</a>');
         });
         it("LESS-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a href <="#">hello</a>')).to.equal('<a href ="#">hello</a>');
+            expect(contextParser.contextualize('<a href <="#">hello</a>')).to.equal('<a href ="#">hello</a>');
         });
     });
 
     describe("Parse Error Correction in BEFORE ATTRIBUTE VALUE", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<a href=\x00x>hello</a>')).to.equal('<a href=\uFFFDx>hello</a>');
+            expect(contextParser.contextualize('<a href=\x00x>hello</a>')).to.equal('<a href=\uFFFDx>hello</a>');
         });
         it("GREATER-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a href=>hello</a>')).to.equal('<a href>hello</a>');
+            expect(contextParser.contextualize('<a href=>hello</a>')).to.equal('<a href>hello</a>');
         });
         it("LESS-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a href=<x>hello</a>')).to.equal('<a href=&lt;x>hello</a>');
-            expect(contextParser.parsePartial('<a href=<>hello</a>')).to.equal('<a href=&lt;>hello</a>');
+            expect(contextParser.contextualize('<a href=<x>hello</a>')).to.equal('<a href=&lt;x>hello</a>');
+            expect(contextParser.contextualize('<a href=<>hello</a>')).to.equal('<a href=&lt;>hello</a>');
         });
         it("EQUALS SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a href==x>hello</a>')).to.equal('<a href=&#61;x>hello</a>');
-            expect(contextParser.parsePartial('<a href==>hello</a>')).to.equal('<a href=&#61;>hello</a>');
+            expect(contextParser.contextualize('<a href==x>hello</a>')).to.equal('<a href=&#61;x>hello</a>');
+            expect(contextParser.contextualize('<a href==>hello</a>')).to.equal('<a href=&#61;>hello</a>');
         });
         it("GRAVE ACCENT treatment", function() {
-            expect(contextParser.parsePartial('<a href=`x`>hello</a>')).to.equal('<a href=&#96;x&#96;>hello</a>');
-            expect(contextParser.parsePartial('<a href=`>hello</a>')).to.equal('<a href=&#96;>hello</a>');
+            expect(contextParser.contextualize('<a href=`x`>hello</a>')).to.equal('<a href=&#96;x&#96;>hello</a>');
+            expect(contextParser.contextualize('<a href=`>hello</a>')).to.equal('<a href=&#96;>hello</a>');
         });
     });
 
     describe("Parse Error Correction in ATTRIBUTE VALUE (DOUBLE-QUOTED)", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<a href="\x00">hello</a>')).to.equal('<a href="\uFFFD">hello</a>');
+            expect(contextParser.contextualize('<a href="\x00">hello</a>')).to.equal('<a href="\uFFFD">hello</a>');
         });
     });
 
     describe("Parse Error Correction in ATTRIBUTE VALUE (SINGLE-QUOTED)", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<a href=\'\x00\'>hello</a>')).to.equal('<a href=\'\uFFFD\'>hello</a>');
+            expect(contextParser.contextualize('<a href=\'\x00\'>hello</a>')).to.equal('<a href=\'\uFFFD\'>hello</a>');
         });
     });
 
     describe("Parse Error Correction in ATTRIBUTE VALUE (UNQUOTED)", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<a href=x\x00>hello</a>')).to.equal('<a href=x\uFFFD>hello</a>');
+            expect(contextParser.contextualize('<a href=x\x00>hello</a>')).to.equal('<a href=x\uFFFD>hello</a>');
         });
         it("QUOTATION MARK treatment", function() {
-            expect(contextParser.parsePartial('<a href=x">hello</a>')).to.equal('<a href=x&quot;>hello</a>');
+            expect(contextParser.contextualize('<a href=x">hello</a>')).to.equal('<a href=x&quot;>hello</a>');
         });
         it("APOSTROPHE treatment", function() {
-            expect(contextParser.parsePartial('<a href=x\'>hello</a>')).to.equal('<a href=x&#39;>hello</a>');
+            expect(contextParser.contextualize('<a href=x\'>hello</a>')).to.equal('<a href=x&#39;>hello</a>');
         });
         it("LESS-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a href=x<>hello</a>')).to.equal('<a href=x&lt;>hello</a>');
-            expect(contextParser.parsePartial('<a href=<>hello</a>')).to.equal('<a href=&lt;>hello</a>');
+            expect(contextParser.contextualize('<a href=x<>hello</a>')).to.equal('<a href=x&lt;>hello</a>');
+            expect(contextParser.contextualize('<a href=<>hello</a>')).to.equal('<a href=&lt;>hello</a>');
         });
         it("EQUALS SIGN treatment", function() {
-            expect(contextParser.parsePartial('<a href=x=>hello</a>')).to.equal('<a href=x&#61;>hello</a>');
-            expect(contextParser.parsePartial('<a href==>hello</a>')).to.equal('<a href=&#61;>hello</a>');
+            expect(contextParser.contextualize('<a href=x=>hello</a>')).to.equal('<a href=x&#61;>hello</a>');
+            expect(contextParser.contextualize('<a href==>hello</a>')).to.equal('<a href=&#61;>hello</a>');
         });
         it("GRAVE ACCENT treatment", function() {
-            expect(contextParser.parsePartial('<a href=x`>hello</a>')).to.equal('<a href=x&#96;>hello</a>');
-            expect(contextParser.parsePartial('<a href=`>hello</a>')).to.equal('<a href=&#96;>hello</a>');
+            expect(contextParser.contextualize('<a href=x`>hello</a>')).to.equal('<a href=x&#96;>hello</a>');
+            expect(contextParser.contextualize('<a href=`>hello</a>')).to.equal('<a href=&#96;>hello</a>');
         });
     });
 
     describe("Parse Error Correction in AFTER ATTRIBUTE VALUE (QUOTED)", function() {
         it("ANYTHING ELSE treatment", function() {
-            expect(contextParser.parsePartial('<img src="x" onclick=""/>')).to.equal('<img src="x" onclick=""/>');
-            expect(contextParser.parsePartial('<img src="x"onclick=""/>')).to.equal('<img src="x" onclick=""/>');
+            expect(contextParser.contextualize('<img src="x" onclick=""/>')).to.equal('<img src="x" onclick=""/>');
+            expect(contextParser.contextualize('<img src="x"onclick=""/>')).to.equal('<img src="x" onclick=""/>');
         });
     });
 
     describe("Parse Error Correction in SELF-CLOSING START TAG", function() {
         it("ANYTHING ELSE treatment", function() {
-            expect(contextParser.parsePartial('<br/ onclick="">')).to.equal('<br  onclick="">');
-            expect(contextParser.parsePartial('<br/onclick="">')).to.equal('<br onclick="">');
+            expect(contextParser.contextualize('<br/ onclick="">')).to.equal('<br  onclick="">');
+            expect(contextParser.contextualize('<br/onclick="">')).to.equal('<br onclick="">');
 
-            expect(contextParser.parsePartial('<br /onclick="">')).to.equal('<br  onclick="">');
-            expect(contextParser.parsePartial('<br oncl/ick="">')).to.equal('<br oncl ick="">');
-            expect(contextParser.parsePartial('<br onclick /="">')).to.equal('<br onclick  >');
-            expect(contextParser.parsePartial('<br onclick/="alert(1)">')).to.equal('<br onclick alert(1)>');
-            expect(contextParser.parsePartial('<br onclick /="alert(1)">')).to.equal('<br onclick  alert(1)>');
+            expect(contextParser.contextualize('<br /onclick="">')).to.equal('<br  onclick="">');
+            expect(contextParser.contextualize('<br oncl/ick="">')).to.equal('<br oncl ick="">');
+            expect(contextParser.contextualize('<br onclick /="">')).to.equal('<br onclick  >');
+            expect(contextParser.contextualize('<br onclick/="alert(1)">')).to.equal('<br onclick alert(1)>');
+            expect(contextParser.contextualize('<br onclick /="alert(1)">')).to.equal('<br onclick  alert(1)>');
         });
     });
 
     describe("Parse Error Correction in MARKUP DECLARATION OPEN", function() {
         it("doctype treatment", function() {
-            expect(contextParser.parsePartial('<!doctype html>')).to.equal('<!doctype html>');
-            expect(contextParser.parsePartial('<!doctype html5>')).to.equal('<!--!doctype html5--><!doctype html>');
-            expect(contextParser.parsePartial('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">'))
+            expect(contextParser.contextualize('<!doctype html>')).to.equal('<!doctype html>');
+            expect(contextParser.contextualize('<!doctype html5>')).to.equal('<!--!doctype html5--><!doctype html>');
+            expect(contextParser.contextualize('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">'))
                 .to.equal('<!--!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"--><!doctype html>');
         });
         it("[CDATA[ treatment", function() {
-            expect(contextParser.parsePartial('<math><ms><![CDATA[x<y]]></ms></math>')).to.equal('<math><ms><![CDATA[x<y]]></ms></math>');
+            expect(contextParser.contextualize('<math><ms><![CDATA[x<y]]></ms></math>')).to.equal('<math><ms><![CDATA[x<y]]></ms></math>');
         });
         it("standard comment treatment", function() {
-            expect(contextParser.parsePartial('<!--hello-->')).to.equal('<!--hello-->');
+            expect(contextParser.contextualize('<!--hello-->')).to.equal('<!--hello-->');
         });
     });
 
     describe("Parse Error Correction in COMMENT START", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<!--\x00-->')).to.equal('<!--\uFFFD-->');
+            expect(contextParser.contextualize('<!--\x00-->')).to.equal('<!--\uFFFD-->');
         });
         it("GREATER-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('<!-->')).to.equal('<!---->');
+            expect(contextParser.contextualize('<!-->')).to.equal('<!---->');
         });
     });
 
     describe("Parse Error Correction in COMMENT START DASH", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<!---\x00-->')).to.equal('<!---\uFFFD-->');
+            expect(contextParser.contextualize('<!---\x00-->')).to.equal('<!---\uFFFD-->');
         });
         it("GREATER-THAN SIGN treatment", function() {
-            expect(contextParser.parsePartial('<!--->')).to.equal('<!---->');
+            expect(contextParser.contextualize('<!--->')).to.equal('<!---->');
         });
 
     });
 
     describe("Parse Error Correction in COMMENT", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<!-- \x00-->')).to.equal('<!-- \uFFFD-->');
+            expect(contextParser.contextualize('<!-- \x00-->')).to.equal('<!-- \uFFFD-->');
         });
     });
 
     describe("Parse Error Correction in COMMENT END DASH", function() {
         it("NULL treatment", function() {
-            // expect(contextParser.parsePartial('<!---\x00->')).to.equal('<!---\uFFFD->');
-            expect(contextParser.parsePartial('<!---\x00>-->')).to.equal('<!---\uFFFD>-->');
+            // expect(contextParser.contextualize('<!---\x00->')).to.equal('<!---\uFFFD->');
+            expect(contextParser.contextualize('<!---\x00>-->')).to.equal('<!---\uFFFD>-->');
         });
     });
 
     describe("Parse Error Correction in COMMENT END", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<!----\x00>-->')).to.equal('<!----\uFFFD>-->');
+            expect(contextParser.contextualize('<!----\x00>-->')).to.equal('<!----\uFFFD>-->');
         });
         it("EXCLAMATION MARK treatment", function() {
-            expect(contextParser.parsePartial('<!--abc--!>')).to.equal('<!--abc-->');
-            expect(contextParser.parsePartial('<!--abc--!-->')).to.equal('<!--abc--!-->');
-            expect(contextParser.parsePartial('<!--abc--! -->')).to.equal('<!--abc--! -->');
-            expect(contextParser.parsePartial('<!--abc--! --!>')).to.equal('<!--abc--! -->');
+            expect(contextParser.contextualize('<!--abc--!>')).to.equal('<!--abc-->');
+            expect(contextParser.contextualize('<!--abc--!-->')).to.equal('<!--abc--!-->');
+            expect(contextParser.contextualize('<!--abc--! -->')).to.equal('<!--abc--! -->');
+            expect(contextParser.contextualize('<!--abc--! --!>')).to.equal('<!--abc--! -->');
         });
         it("HYPHEN-MINUS treatment", function() {
-            expect(contextParser.parsePartial('<!--abc--->')).to.equal('<!--abc--->');
+            expect(contextParser.contextualize('<!--abc--->')).to.equal('<!--abc--->');
         });
         it("ANYTHING ELSE treatment", function() {
-            expect(contextParser.parsePartial('<!--abc--a-->')).to.equal('<!--abc--a-->');
+            expect(contextParser.contextualize('<!--abc--a-->')).to.equal('<!--abc--a-->');
         });
     });
 
     describe("Parse Error Correction in COMMENT END BANG", function() {
         it("NULL treatment", function() {
-            expect(contextParser.parsePartial('<!----!\x00>-->')).to.equal('<!----!\uFFFD>-->');
+            expect(contextParser.contextualize('<!----!\x00>-->')).to.equal('<!----!\uFFFD>-->');
         });
     });
 


### PR DESCRIPTION
This PR includes the following changes, please comment

* The function of Strict Context Parser will be added to the Parser and its corresponding features can be enabled through config object as shown below (default value)
```
var config = {
  enableInputPreProcessing: true,
  enableCanonicalization: false,
  enableIEConditionalComments: false,
  enableStateTracking: true
};
var p = new Parser(config)
```

* remove of the parsePartial function and use contextualize function for the context analysis.
* add the logic to avoid the input string split and array join if the canonicalization is disable to improve the performance.