### PR TITLE
Apply input preprocessing by default

### DIFF
--- a/tests/unit/run-strict-context-parser.js
+++ b/tests/unit/run-strict-context-parser.js
@@ -28,8 +28,8 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(contextParser.contextualize('\x0B')).to.equal('\uFFFD');
         });
         it('unicode non-character U+1FFFF and U+1FFFE treatment', function () {
-            expect(contextParser.contextualize('\uD83F\uDFFE')).to.equal('\uFFFD\uFFFD');  //U+1FFFE
-            expect(contextParser.contextualize('\uD83F\uDFFF')).to.equal('\uFFFD\uFFFD');  //U+1FFFF
+            expect(contextParser.contextualize('\uD83F\uDFFE')).to.equal('\uFFFD');  //U+1FFFE
+            expect(contextParser.contextualize('\uD83F\uDFFF')).to.equal('\uFFFD');  //U+1FFFF
         });
     });
 


### PR DESCRIPTION
- This is to conform with the html 5 specification, and is thus turned
on by default. Reference:
https://html.spec.whatwg.org/multipage/syntax.html#preprocessing-the-input-stream
- The implementation incurs negligible performance hit (from 25.60MB/s
to 25.52MB/s, averaged over 5 times of running ./bin/benchmark)
- This implementation is arrived after comparing
regexp and char-by-char replacement.
- Given there are negligible performance overhead, extended and turned it on by default even for FastParser