### PR TITLE
Avoided string split() and join() in HTML Canonicalization.

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -20,10 +20,17 @@ var allParsers = parsers.concat([
     ['HtmlParser2', 'htmlparser2', 'Parser', 'end'],
 ]);
 
-console.log("Usage: benchmark [all]");
+var selfParsers = [
+    ['Context Parser (FastParser)', '../src/context-parser', 'FastParser', 'contextualize', {}],
+    ['Context Parser (Parser)', '../src/context-parser', 'Parser', 'contextualize', {}],
+    ['Context Parser (Parser,stateTracking=Off)', '../src/context-parser', 'Parser', 'contextualize', {enableStateTracking: false}],
+    ['Context Parser (Parser,stateTracking=Off,canonicalization=On)', '../src/context-parser', 'Parser', 'contextualize', {enableStateTracking: false, enableCanonicalization: true}]
+];
+
+console.log("Usage: benchmark [all|self]");
 
 if ( process.argv.length > 2 ) {
-    parsers = allParsers;
+    parsers = process.argv[3] === 'all' ? allParsers : selfParsers;
 }
 
 parsers.forEach(function(parser) {
@@ -33,13 +40,14 @@ parsers.forEach(function(parser) {
     var classname = parser[1];
     var name = parser[2];
     var method = parser[3];
+    var config = parser[4];
 
     try {
         if ( name || method ) {
             var Parser = name ? require(classname)[name] : require(classname);
             start = +new Date();
             for(var i=0; i<10; i++) {
-                var parser = new Parser();
+                var parser = config ? new Parser(config) : new Parser();
                 parser[method](html);
             }
             end = +new Date();


### PR DESCRIPTION
- the problem has largely affected the performance of canonicalization
- `String.split('')` and `String.join('')` was found very slow when given a large string
- replaced the operations with an equiv. string-based manipulation
- performance improved by **>3x** from 0.808MB/s to 2.535MB/s
